### PR TITLE
fix linking error on mingw build

### DIFF
--- a/include/OgreVideoManager.h
+++ b/include/OgreVideoManager.h
@@ -75,7 +75,7 @@ namespace Ogre
 		TheoraVideoManager* getTheoraVideoManager();
 	};
 
-    class OgreVideoPlugin : public Plugin
+    class _OgreTheoraExport OgreVideoPlugin : public Plugin
     {
 	    OgreVideoManager* mVideoMgr;
     public:


### PR DESCRIPTION
in mingw environment without __declspec() on OgreVideoPlugin linking project with Plugin_TheoraVideoSystem DLL ends with "undefined reference to `vtable for Ogre::OgreVideoPlugin'" error