### PR TITLE
multiple textures from the same input file and some code cleanup

### DIFF
--- a/theoravideo/include/OgreVideoManager.h
+++ b/theoravideo/include/OgreVideoManager.h
@@ -76,7 +76,7 @@ namespace Ogre
 	
 	class _OgreTheoraExport OgreVideoPlugin : public Plugin
 	{
-		OgreVideoManager* mVideoMgr;
+		static OgreVideoManager* mVideoMgr;
 	public:
 		const String& getName() const;
 		void install() {}

--- a/theoravideo/include/OgreVideoManager.h
+++ b/theoravideo/include/OgreVideoManager.h
@@ -67,6 +67,9 @@ namespace Ogre
 		void destroyAdvancedTexture(const String& material_name,
 									const String& groupName = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 		
+		/// destroy all video textures
+		void destroyAllVideoTexture();
+		
 		/// pause all video
 		void pauseAllVideoClips();
 		

--- a/theoravideo/include/OgreVideoManager.h
+++ b/theoravideo/include/OgreVideoManager.h
@@ -36,7 +36,7 @@ namespace Ogre
 		
 		/**
 			@remarks
-				Creates a texture into an already defined material
+				Creates video clip and a texture into an already defined material.
 				All setting should have been set before calling this.
 				Refer to base class ( ExternalTextureSource ) for details
 			@param material_name
@@ -44,6 +44,18 @@ namespace Ogre
 		*/
 		void createDefinedTexture(const String& material_name,
 								  const String& group_name = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+		
+		/**
+			@remarks
+				Creates video clip and  a texture into an already defined material.
+			@param video_file_name
+				Video input file name.
+			@param material_name
+				Material  you are attaching a movie to.
+		*/
+		TheoraVideoClip* createVideoTexture(const String& video_file_name, const String& material_name,
+											const String& video_group_name = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
+											const String& group_name = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 		
 		/**
 			@remarks
@@ -61,8 +73,20 @@ namespace Ogre
 		/// unpause all video
 		void unpauseAllVideoClips();
 		
+		/**
+			@remarks
+				Return video clip based on material name
+			@param material_name
+				Material Name you are looking to remove a video clip from
+		*/
+		TheoraVideoClip* getVideoClipByMaterialName(const String& material_name);
+		
 	private:
-		std::map<std::string,TexturePtr> mTextures;
+		struct ClipTexture {
+			TheoraVideoClip*  clip;
+			TexturePtr        texture;
+		};
+		std::map<String,ClipTexture> mClipsTextures;
 		bool mbInit;
 		bool mbPaused;
 		

--- a/theoravideo/include/OgreVideoManager.h
+++ b/theoravideo/include/OgreVideoManager.h
@@ -30,20 +30,10 @@ namespace Ogre
 											   public FrameListener,
 											   public TheoraVideoManager
 	{
-		std::map<std::string,TexturePtr> mTextures;
-		bool mbInit;
-		bool mbPaused;
 	public:
 		OgreVideoManager(int num_worker_threads=1);
 		~OgreVideoManager();
-
-		/**
-			@remarks
-				This function is called to init this plugin - do not call directly
-		*/
-		bool initialise();
-		void shutDown();
-
+		
 		/**
 			@remarks
 				Creates a texture into an already defined material
@@ -53,7 +43,7 @@ namespace Ogre
 				Material  you are attaching a movie to.
 		*/
 		void createDefinedTexture(const String& material_name,
-                                  const String& group_name = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+								  const String& group_name = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 		
 		/**
 			@remarks
@@ -63,28 +53,37 @@ namespace Ogre
 				Material Name you are looking to remove a video clip from
 		*/
 		void destroyAdvancedTexture(const String& material_name,
-                                    const String& groupName = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
-
-		bool frameStarted(const FrameEvent& evt);
-
-        bool setParameter(const String &name,const String &value);
-        String getParameter(const String &name) const;
-        
+									const String& groupName = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+		
+		/// pause all video
 		void pauseAllVideoClips();
+		
+		/// unpause all video
 		void unpauseAllVideoClips();
-		TheoraVideoManager* getTheoraVideoManager();
+		
+	private:
+		std::map<std::string,TexturePtr> mTextures;
+		bool mbInit;
+		bool mbPaused;
+		
+		// This function is called on start new frame by Ogre - do not call directly
+		bool frameStarted(const FrameEvent& evt);
+		
+		// This function is called to init this plugin - do not call directly
+		bool initialise();
+		void shutDown();
 	};
-
-    class _OgreTheoraExport OgreVideoPlugin : public Plugin
-    {
-	    OgreVideoManager* mVideoMgr;
-    public:
-        const String& getName() const;
-        void install() {}
-        void uninstall() {}
-        void initialise();
-        void shutdown();
-    };
+	
+	class _OgreTheoraExport OgreVideoPlugin : public Plugin
+	{
+		OgreVideoManager* mVideoMgr;
+	public:
+		const String& getName() const;
+		void install() {}
+		void uninstall() {}
+		void initialise();
+		void shutdown();
+	};
 }
 #endif
 

--- a/theoravideo/include/OgreVideoManager.h
+++ b/theoravideo/include/OgreVideoManager.h
@@ -68,7 +68,7 @@ namespace Ogre
 									const String& groupName = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 		
 		/// destroy all video textures
-		void destroyAllVideoTexture();
+		void destroyAllVideoTextures();
 		
 		/// pause all video
 		void pauseAllVideoClips();

--- a/theoravideo/src/OgreVideoManager.cpp
+++ b/theoravideo/src/OgreVideoManager.cpp
@@ -150,7 +150,7 @@ namespace Ogre
 		mClipsTextures.erase(it);
 	}
 	
-	void OgreVideoManager::destroyAllVideoTexture() {
+	void OgreVideoManager::destroyAllVideoTextures() {
 		for (std::map<String,ClipTexture>::iterator it=mClipsTextures.begin(); it!=mClipsTextures.end(); it++) {
 			destroyVideoClip(it->second.clip);
 		}

--- a/theoravideo/src/OgreVideoManager.cpp
+++ b/theoravideo/src/OgreVideoManager.cpp
@@ -149,6 +149,13 @@ namespace Ogre
 		destroyVideoClip(it->second.clip); // OgreTheoraDataStream will be destroyed in TheoraVideoClip destructor
 		mClipsTextures.erase(it);
 	}
+	
+	void OgreVideoManager::destroyAllVideoTexture() {
+		for (std::map<String,ClipTexture>::iterator it=mClipsTextures.begin(); it!=mClipsTextures.end(); it++) {
+			destroyVideoClip(it->second.clip);
+		}
+		mClipsTextures.clear();
+	}
 
 	bool OgreVideoManager::frameStarted(const FrameEvent& evt)
 	{

--- a/theoravideo/src/OgreVideoManager.cpp
+++ b/theoravideo/src/OgreVideoManager.cpp
@@ -177,7 +177,9 @@ namespace Ogre
 	{
 		Ogre::LogManager::getSingleton().logMessage("OgreVideo: "+message);
 	}
-
+	
+	OgreVideoManager* OgreVideoPlugin::mVideoMgr = 0;
+	
 	const String& OgreVideoPlugin::getName() const
 	{
 		static String name = "TheoraVideoPlugin";
@@ -185,6 +187,13 @@ namespace Ogre
 	}
 	void OgreVideoPlugin::initialise()
 	{
+		if (mVideoMgr) {
+			Ogre::LogManager::getSingleton().logMessage(
+				"WARNING: OgreVideoPlugin was already been initialized ... ignoring next initialise of plugin"
+			);
+			return;
+		}
+		
 		TheoraVideoManager::setLogFunction(ogrevideo_log);
 		// Create our new External Texture Source PlugIn
 		mVideoMgr = new OgreVideoManager();
@@ -197,6 +206,7 @@ namespace Ogre
 	{
 		Root::getSingleton().removeFrameListener(mVideoMgr);
 		delete mVideoMgr;
+		mVideoMgr = 0;
 	}
 
 } // end namespace Ogre

--- a/theoravideo/src/OgreVideoManager.cpp
+++ b/theoravideo/src/OgreVideoManager.cpp
@@ -53,27 +53,12 @@ namespace Ogre
 		return y;
 	}
 
-	class ManualTimer : public TheoraTimer
-	{
-	public:
-		void update(float t)
-		{
-		
-		}
-
-		void setTime(float time)
-		{
-			mTime=time;
-		}
-	};
-
 	OgreVideoManager::OgreVideoManager(int num_worker_threads) : TheoraVideoManager(num_worker_threads)
 	{
 		mDictionaryName = "TheoraVideoPlugin";
 		mbInit=false;
 		mbPaused=false;
 		mTechniqueLevel=mPassLevel=mStateLevel=0;
-
 		initialise();
 	}
 
@@ -93,19 +78,8 @@ namespace Ogre
 	void OgreVideoManager::shutDown()
 	{
 		if (!mbInit) return;
-
 		mbInit=false;
 	}
-    
-    bool OgreVideoManager::setParameter(const String &name,const String &value)
-    {
-        return ExternalTextureSource::setParameter(name, value);
-    }
-    
-    String OgreVideoManager::getParameter(const String &name) const
-    {
-        return ExternalTextureSource::getParameter(name);
-    }
 
 	void OgreVideoManager::createDefinedTexture(const String& material_name,const String& group_name)
 	{
@@ -156,8 +130,6 @@ namespace Ogre
 	void OgreVideoManager::destroyAdvancedTexture(const String& material_name,const String& groupName)
 	{
 		logMessage("Destroying ogg_video texture on material: "+material_name);
-
-		//logMessage("Error destroying ogg_video texture, texture not found!");
 	}
 
 	bool OgreVideoManager::frameStarted(const FrameEvent& evt)
@@ -168,7 +140,7 @@ namespace Ogre
 		if (evt.timeSinceLastFrame > 0.3f)
 			update(0.3f);
 		else
-		    update(evt.timeSinceLastFrame);
+			update(evt.timeSinceLastFrame);
 
 		// update playing videos
 		std::vector<TheoraVideoClip*>::iterator it;
@@ -201,30 +173,30 @@ namespace Ogre
 		mbPaused = false;
 	}
 	
-    static void ogrevideo_log(std::string message)
-    {
-        Ogre::LogManager::getSingleton().logMessage("OgreVideo: "+message);
-    }
+	static void ogrevideo_log(std::string message)
+	{
+		Ogre::LogManager::getSingleton().logMessage("OgreVideo: "+message);
+	}
 
-    const String& OgreVideoPlugin::getName() const
-    {
-        static String name = "TheoraVideoPlugin";
-        return name;
-    }
-    void OgreVideoPlugin::initialise()
-    {
-        TheoraVideoManager::setLogFunction(ogrevideo_log);
-        // Create our new External Texture Source PlugIn
-        mVideoMgr = new OgreVideoManager();
+	const String& OgreVideoPlugin::getName() const
+	{
+		static String name = "TheoraVideoPlugin";
+		return name;
+	}
+	void OgreVideoPlugin::initialise()
+	{
+		TheoraVideoManager::setLogFunction(ogrevideo_log);
+		// Create our new External Texture Source PlugIn
+		mVideoMgr = new OgreVideoManager();
 
-        // Register with Manager
-        ExternalTextureSourceManager::getSingleton().setExternalTextureSource("ogg_video",mVideoMgr);
-        Root::getSingleton().addFrameListener(mVideoMgr);
-    }
-    void OgreVideoPlugin::shutdown()
-    {
-        Root::getSingleton().removeFrameListener(mVideoMgr);
-        delete mVideoMgr;
-    }
+		// Register with Manager
+		ExternalTextureSourceManager::getSingleton().setExternalTextureSource("ogg_video",mVideoMgr);
+		Root::getSingleton().addFrameListener(mVideoMgr);
+	}
+	void OgreVideoPlugin::shutdown()
+	{
+		Root::getSingleton().removeFrameListener(mVideoMgr);
+		delete mVideoMgr;
+	}
 
 } // end namespace Ogre


### PR DESCRIPTION
- allow creating multiple textures from the same video input file, with independent time, play/pause constrols
- OgreVideoManager store mapping material name with texture objects and video clip getVideoClipByMaterialName() to get video clips by material name
- function createVideoTexture() for creating video texture and return clip (instead of sequence call  setInputName(), createDefinedTexture() and getVideoClipByMaterialName())
- add protection against multiple initialise of OgreVideoPlugin
- remove unused/redundancy code