### PR TITLE
Some CMake fixes and an additional option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,15 +10,15 @@ include(GenerateExportHeader)
 
 SET(CMAKE_DEBUG_POSTFIX "_d")
 if(OGRE_PREFIX_DIR)
-  set(CMAKE_INSTALL_PREFIX ${OGRE_PREFIX_DIR} CACHE PATH "plugin must end up in OGRE plugin path" FORCE)
+	set(CMAKE_INSTALL_PREFIX ${OGRE_PREFIX_DIR} CACHE PATH "plugin must end up in OGRE plugin path" FORCE)
 endif()
 
 if(BUILD_VIDEOPLUGIN)
-  add_subdirectory(theoravideo)
+	add_subdirectory(theoravideo)
 endif()
 
 if(BUILD_AUDIOPLUGIN)
-  add_subdirectory(oggsound)
+	add_subdirectory(oggsound)
 endif()
 
 if (NOT OGRE_Bites_FOUND)
@@ -28,9 +28,16 @@ if (NOT OGRE_Bites_FOUND)
 	set(BUILD_DEMOS OFF)
 endif (NOT OGRE_Bites_FOUND)
 
+if (NOT BUILD_VIDEOPLUGIN OR NOT BUILD_AUDIOPLUGIN)
+	if (BUILD_DEMOS)
+		message(WARNING "Building Demos require both audio and video plugins - disable build demos")
+	endif (BUILD_DEMOS)
+	set(BUILD_DEMOS OFF)
+endif (NOT BUILD_VIDEOPLUGIN OR NOT BUILD_AUDIOPLUGIN)
+
 if (BUILD_DEMOS)
 	add_executable(player demos/player/player.cpp)
-  target_link_libraries(player OgreBites Plugin_TheoraVideoSystem Plugin_OggSound)
+	target_link_libraries(player OgreBites Plugin_TheoraVideoSystem Plugin_OggSound)
 	target_include_directories(player PUBLIC ${OPENAL_INCLUDE_DIRS})
 
 	file(COPY demos/resources.cfg DESTINATION ${CMAKE_BINARY_DIR})

--- a/oggsound/CMakeLists.txt
+++ b/oggsound/CMakeLists.txt
@@ -35,6 +35,7 @@ SET (SOURCE_FILES
 # Option.
 option(OGGSOUND_THREADED "Enable multi-threaded streamed sounds" OFF)
 option(USE_POCO "Use POCO Threads?" OFF)
+option(USE_EFX "Use EFX? Disable this if you are using OpenAl Soft" OFF)
 
 IF(OGGSOUND_THREADED)
   IF(USE_POCO)
@@ -56,6 +57,10 @@ IF(OGGSOUND_THREADED)
 	ENDIF()	 
 ELSE()
     ADD_DEFINITIONS(-DOGGSOUND_THREADED=0)
+ENDIF()
+
+IF(USE_EFX)
+	ADD_DEFINITIONS(-DHAVE_EFX=1)
 ENDIF()
 
 FIND_PACKAGE(PkgConfig QUIET)


### PR DESCRIPTION
 - If audio or video plugin are not built then demo should not be built
 - Add option to enable/disable EFX since compiling against OpenAL Soft fails with EFX enabled