### PR TITLE
Check that SceneManager actually exists before cleaning dangling sounds

### DIFF
--- a/oggsound/src/OgreOggSoundManager.cpp
+++ b/oggsound/src/OgreOggSoundManager.cpp
@@ -215,7 +215,10 @@ namespace OgreOggSound
 		if ( mListener )
 		{
 			Ogre::SceneManager* s = mListener->getSceneManager();
-			s->destroyAllMovableObjectsByType("OgreOggISound");
+
+			if(s != nullptr && Ogre::Root::getSingletonPtr()->hasSceneManager(s->getName()))
+				s->destroyAllMovableObjectsByType("OgreOggISound");
+
 			_destroyListener();
 		}
 	}


### PR DESCRIPTION
This fix is for #15, I thought that using `mSoundManager->setSceneManager(nullptr);` fixed the problem but it still shows when using the debugger.

So I made this change that is not perfect because it is calling `getName()` on a SceneManager that might not exist but it works even if the SceneManager does not exist.

With this change it is not even needed to use the `setSceneManager(nullptr)` workaround.
