### PR TITLE
Use ALC_ENUMERATE_ALL_EXT to get more detailed device descriptions

### DIFF
--- a/oggsound/include/OgreOggSoundManager.h
+++ b/oggsound/include/OgreOggSoundManager.h
@@ -140,10 +140,10 @@ namespace OgreOggSound
 				Desired size of queue list (optional | Multi-threaded ONLY)
 		 */
 		bool init(const std::string &deviceName = "", unsigned int maxSources=100, unsigned int queueListSize=100, Ogre::SceneManager* sMan=0);
-		/** Gets the openal device ptr
+		/** Gets the OpenAL device pointer
 		*/
 		const ALCdevice* getOpenalDevice() { return mDevice; }
-		/** Gets the openal context ptr
+		/** Gets the OpenAL context pointer
 		*/
 		const ALCcontext* getOpenalContext() { return mContext; }
 		/** Sets the global volume for all sounds
@@ -883,7 +883,7 @@ namespace OgreOggSound
 		void _reactivateQueuedSoundsImpl();
 		/** Enumerates audio devices.
 		@remarks
-			Gets a list of audio device available.
+			Gets a list of audio devices available.
 		 */
 		void _enumDevices();
 		/** Creates a listener object.


### PR DESCRIPTION
There were some inconsistencies in the way that the device list was generated.

`OgreOggSoundManager::init` was calling `OgreOggSoundManager::_enumDevices()` but its result was not being used (Now it is used as the source of truth)
The function `OgreOggSoundManager::getDeviceList()` had initialization code to test the devices, which is unexpected behaviour for a `get*()` function, now it only returns the list
The previous version of `OgreOggSoundManager::getDeviceList()` was creating and destroying `ALContext` for each device to sort of "test" it, but in practice it makes more sense to just get the device list and fail later in the initialization if we are unable to create the context for that particular device.

With these changes it is now safe to call `OgreOggSoundManager::getDeviceList()`, I was having problems with it previously.

The code now resembles the way in which OpenAL Soft is initialized in the `openal-info.c` example.
