### PR TITLE
Remove erroneous initialization parameter

### DIFF
--- a/oggsound/src/OgreOggISound.cpp
+++ b/oggsound/src/OgreOggISound.cpp
@@ -520,7 +520,6 @@ namespace OgreOggSound
 			alSourcef (mSource, AL_PITCH, mPitch);
 			alSourcei (mSource, AL_SOURCE_RELATIVE, mSourceRelative);
 			alSourcei (mSource, AL_LOOPING, mStream ? AL_FALSE : mLoop);
-			alSourcei (mSource, AL_SOURCE_STATE, AL_INITIAL);
 			mInitialised = true;
 		}
 	}


### PR DESCRIPTION
`AL_SOURCE_STATE` is a read-only attibute of a sound source, sound sources start at `AL_INITIAL` on creation (according to OpenAL 1.1 spec).
(This was detected thanks to OpenAL Soft debugging)
