### PR TITLE
API correction regarding EFX Effect Slots

### DIFF
--- a/oggsound/include/OgreOggSoundManager.h
+++ b/oggsound/include/OgreOggSoundManager.h
@@ -532,11 +532,16 @@ namespace OgreOggSound
 				vector pointer of integer values to set.
 		 */
 		bool setEFXEffectParameter(const std::string& eName, ALint type, ALenum attrib, ALint* params=0);
-		/** Gets the maximum number of Auxiliary Effect slots per source
+		/** Gets the maximum number of Auxiliary Effect Slots detected for the OpenAL device on initialization
 		@remarks
-			Determines how many simultaneous effects can be applied to any one source object
+			Returns how many simultaneous effects can be applied at the same time to the Output Mix.
 		 */
-		int getNumberOfSupportedEffectSlots();
+		int getMaxAuxiliaryEffectSlots() { return mNumEffectSlots; };
+		/** Gets the maximum number of Auxiliary Effect Sends per source
+		@remarks
+			Returns how many simultaneous effects can be applied to any one source object.
+		 */
+		int getMaxAuxiliaryEffectSends() { return mNumSendsPerSource; };
 		/** Gets the number of currently created Auxiliary Effect slots
 		@remarks
 			Returns number of slots created and available for effects/filters.

--- a/oggsound/src/OgreOggSoundManager.cpp
+++ b/oggsound/src/OgreOggSoundManager.cpp
@@ -1668,17 +1668,6 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	int OgreOggSoundManager::getNumberOfSupportedEffectSlots()
-	{
-		if ( !hasEFXSupport() ) return 0;
-
-		ALint auxSends=0;
-		alcGetIntegerv(mDevice, ALC_MAX_AUXILIARY_SENDS, 1, &auxSends);
-
-		return auxSends;
-	}
-
-	/*/////////////////////////////////////////////////////////////////*/
 	int OgreOggSoundManager::getNumberOfCreatedEffectSlots()
 	{
 		if ( mEffectSlotList.empty() ) return 0;
@@ -1877,8 +1866,8 @@ namespace OgreOggSound
 		ALuint		uiFilters[1] = { 0 };
 		Ogre::String msg="";
 
-		// To determine how many Auxiliary Effects Slots are available, create as many as possible (up to 128)
-		// until the call fails.
+		// To determine how many Auxiliary Effects Slots are available,
+		// create as many as possible (up to 128) until the call fails.
 		for (mNumEffectSlots = 0; mNumEffectSlots < 128; mNumEffectSlots++)
 		{
 			alGenAuxiliaryEffectSlots(1, &uiEffectSlots[mNumEffectSlots]);
@@ -1886,12 +1875,12 @@ namespace OgreOggSound
 				break;
 		}
 
-		msg="*** --- "+Ogre::StringConverter::toString(mNumEffectSlots)+ " Auxiliary Effect Slot(s)";
+		msg="*** --- " + Ogre::StringConverter::toString(mNumEffectSlots) + " Auxiliary Effect Slot(s)";
 		Ogre::LogManager::getSingleton().logMessage(msg);
 
 		// Retrieve the number of Auxiliary Effect Slots Sends available on each Source
 		alcGetIntegerv(mDevice, ALC_MAX_AUXILIARY_SENDS, 1, &mNumSendsPerSource);
-		msg="*** --- "+Ogre::StringConverter::toString(mNumSendsPerSource)+" Auxiliary Send(s) per Source";
+		msg="*** --- " + Ogre::StringConverter::toString(mNumSendsPerSource) + " Auxiliary Send(s) per Source";
 		Ogre::LogManager::getSingleton().logMessage(msg);
 
 		Ogre::LogManager::getSingleton().logMessage("*** --- Effects supported:");
@@ -2501,7 +2490,7 @@ namespace OgreOggSound
 		{
 			EffectList::iterator iter=mFilterList.begin();
 			for ( ; iter!=mFilterList.end(); ++iter )
-			    alDeleteEffects( 1, &iter->second);
+			    alDeleteFilters( 1, &iter->second);
 			mFilterList.clear();
 		}
 


### PR DESCRIPTION
@paroj, I wonder what do you think of this.
The function `getNumberOfSupportedEffectSlots()` has a confusing name and description.
It says EffectSlots but returns the Auxiliary Sends (not the same thing), the description is also mixing the two concepts.

So I created `getMaxAuxiliaryEffectSlots()` and `getMaxAuxiliaryEffectSends()` which are consistent in naming and description.

What do you think should be done with `getNumberOfSupportedEffectSlots()`?
I thought of replicating the `OGRE_DEPRECATED` macro, but I don't understand where that macro is defined.

Found another bug when releasing the OpenAL effects and filters.
