### PR TITLE
Add support for EFX highpass and bandpass filters

### DIFF
--- a/oggsound/include/OgreOggSoundManager.h
+++ b/oggsound/include/OgreOggSoundManager.h
@@ -423,16 +423,18 @@ namespace OgreOggSound
 		/** Creates a specified EFX filter
 		@remarks
 			Creates a specified EFX filter if hardware supports it.
-			@param eName 
-				name for filter.
-			@param type 
-				see OpenAL docs for available filters.
+			@param eName
+				name for the filter.
+			@param type
+				possible types: AL_FILTER_LOWPASS, AL_FILTER_HIGHPASS, AL_FILTER_BANDPASS.
 			@param gain
-				see OpenAL docs for available filters.
-			@param hfgain 
-				see OpenAL docs for available filters.
+				gain of the allowed frequency band. Range: [0.0, 1.0]
+			@param hfGain
+				desired gain for filtered high frequencies (only affects lowpass and bandpass filters). Range: [0.0, 1.0]
+			@param lfGain
+				desired gain for filtered low frequencies (only affects highpass and bandpass filters). Range: [0.0, 1.0]
 		 */
-		bool createEFXFilter(const std::string& eName, ALint type, ALfloat gain=1.0, ALfloat hfGain=1.0);
+		bool createEFXFilter(const std::string& eName, ALint type, ALfloat gain=1.0, ALfloat hfGain=1.0, ALfloat lfGain=1.0);
 		/** Creates a specified EFX effect
 		@remarks
 			Creates a specified EFX effect if hardware supports it.
@@ -443,7 +445,7 @@ namespace OgreOggSound
 			@param type 
 				see OpenAL docs for available effects.
 			@param props	
-				legacy structure describing a preset reverb effect.
+				legacy structure describing a preset reverb effect. (See efx-presets.h)
 		 */
 #	if HAVE_EFX == 1
 		bool createEFXEffect(const std::string& eName, ALint type, EAXREVERBPROPERTIES* props=0);

--- a/oggsound/src/OgreOggSoundManager.cpp
+++ b/oggsound/src/OgreOggSoundManager.cpp
@@ -948,7 +948,6 @@ namespace OgreOggSound
 		}
 
 		private:
-
 			Ogre::Vector3 mListenerPos;
 	};
 	/*/////////////////////////////////////////////////////////////////*/
@@ -1555,7 +1554,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::createEFXFilter(const std::string& fName, ALint filterType, ALfloat gain, ALfloat hfGain)
+	bool OgreOggSoundManager::createEFXFilter(const std::string& fName, ALint filterType, ALfloat gain, ALfloat hfGain, ALfloat lfGain)
 	{
 		if ( !hasEFXSupport() || fName.empty() || !isEffectSupported(filterType) )
 		{
@@ -1572,21 +1571,47 @@ namespace OgreOggSound
 			return false;
 		}
 
-		if (alIsFilter(filter) && ((filterType==AL_FILTER_LOWPASS) || (filterType==AL_FILTER_HIGHPASS) || (filterType==AL_FILTER_BANDPASS) ))
+		if (alIsFilter(filter))
 		{
 			alFilteri(filter, AL_FILTER_TYPE, filterType);
 			if (alGetError() != AL_NO_ERROR)
 			{
-				Ogre::LogManager::getSingleton().logMessage("*** Filter not supported!");
+				Ogre::LogManager::getSingleton().logMessage("*** Unable to set filter type!");
 				return false;
 			}
 			else
 			{
-				// Set properties
-				alFilterf(filter, AL_LOWPASS_GAIN, gain);
-				alFilterf(filter, AL_LOWPASS_GAINHF, hfGain);
-				mFilterList[fName]=filter;
+				switch(filterType)
+				{
+					case AL_FILTER_LOWPASS:
+						// Set lowpass filter properties
+						alFilterf(filter, AL_LOWPASS_GAIN, gain);
+						alFilterf(filter, AL_LOWPASS_GAINHF, hfGain);
+						mFilterList[fName]=filter;
+					break;
+					case AL_FILTER_HIGHPASS:
+						// Set highpass filter properties
+						alFilterf(filter, AL_LOWPASS_GAIN, gain);
+						alFilterf(filter, AL_HIGHPASS_GAINLF, lfGain);
+						mFilterList[fName]=filter;
+					break;
+					case AL_FILTER_BANDPASS:
+						// Set bandpass filter properties
+						alFilterf(filter, AL_LOWPASS_GAIN, gain);
+						alFilterf(filter, AL_BANDPASS_GAINLF, lfGain);
+						alFilterf(filter, AL_LOWPASS_GAINHF, hfGain);
+						mFilterList[fName]=filter;
+					break;
+					default:
+						Ogre::LogManager::getSingleton().logError("*** Unknown Filter Type");
+					break;
+				}
 			}
+		}
+		else
+		{
+			Ogre::LogManager::getSingleton().logMessage("*** Created filter is not valid!");
+			return false;
 		}
 		return true;
 	}


### PR DESCRIPTION
In the OpenAL _Effects Extension Guide_ it says that highpass and bandpass filters are not implemented yet, but there is already support for them in OpenAL Soft.
