### PR TITLE
Fix most warnings when generating documentation with Doxygen 1.8.20

### DIFF
--- a/oggsound/include/LocklessQueue.h
+++ b/oggsound/include/LocklessQueue.h
@@ -1,9 +1,7 @@
 /**
-* @file LocklessQueue.h
 * @author  Ian Stangoe
-* @version 1.14
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
@@ -23,7 +21,7 @@
 * You should have received a copy of the GNU Lesser General Public License	 
 * along with OgreOggSound.  If not, see <http://www.gnu.org/licenses/>.	 
 *
-* @section DESCRIPTION
+* DESCRIPTION:
 * 
 * Template class for a lockless queue system to pass items from one thread to another.
 * Only 1 thread can push and 1 thread can pop it. 

--- a/oggsound/include/OgreOggISound.h
+++ b/oggsound/include/OgreOggISound.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggISound.h
 * @author  Ian Stangoe
-* @version 1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 
 *
-* @section DESCRIPTION
-* 
-* Base class for a single sound
+* DESCRIPTION: Base class for a single sound
 */
 #pragma once
 
@@ -543,7 +539,7 @@ namespace OgreOggSound
 		@remarks
 			This will only be set if the sound was created through the plugin method createMovableobject().
 		*/
-		inline Ogre::SceneManager* getSceneManager() const { return mScnMan; }   
+		inline Ogre::SceneManager* getSceneManager() const { return mScnMgr; }
 
 		/** Sets a listener object to be notified of events.
 		@remarks
@@ -579,7 +575,7 @@ namespace OgreOggSound
 		@param name
 			Name of sound within manager
 		@param scnMgr
-			SceneManager which create this sound
+			SceneManager which created this sound (if the sound was created through the plugin method createMovableobject()).
 		 */
 		OgreOggISound(
 			const Ogre::String& name, Ogre::SceneManager* scnMgr
@@ -715,7 +711,7 @@ namespace OgreOggSound
 		/** Sound properties 
 		 */
 		ALuint mSource;					// OpenAL Source
-		Ogre::SceneManager* mScnMan;	// SceneManager pointer for plugin registered sounds
+		Ogre::SceneManager* mScnMgr;	// SceneManager pointer for plugin registered sounds
 		Ogre::uint8 mPriority;			// Priority assigned to source 
 		Ogre::Vector3 mPosition;		// 3D position
 		Ogre::Vector3 mDirection;		// 3D direction

--- a/oggsound/include/OgreOggListener.h
+++ b/oggsound/include/OgreOggListener.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundListener.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 
 *
-* @section DESCRIPTION
-* 
-* Listener object (The users 'ears')
+* DESCRIPTION: Listener object (The users 'ears')
 */
 
 #pragma once
@@ -125,7 +121,7 @@ namespace OgreOggSound
 		Ogre::Vector3 getOrientation() const;
 		/** Sets sounds velocity.
 		@param
-			vel 3D x/y/z velocity
+			velx/vely/velz componentes of 3D vector velocity
 		 */
 		void setVelocity(float velx, float vely, float velz);
 		/** Sets sounds velocity.

--- a/oggsound/include/OgreOggSound.h
+++ b/oggsound/include/OgreOggSound.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSound.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 	 
 *
-* @section DESCRIPTION
-* 
-* Library Headers
+* DESCRIPTION: Library Headers
 */
 
 #pragma once

--- a/oggsound/include/OgreOggSoundCallback.h
+++ b/oggsound/include/OgreOggSoundCallback.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundCallback.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE.  
 *
-* @section DESCRIPTION
-* 
-* Callbacks for detecting various states
+* DESCRIPTION: Callbacks for detecting various states
 */
 
 #ifndef _OGREOGGSOUND_CALLBACK_H_
@@ -45,8 +41,8 @@ namespace OgreOggSound
 	//! Callbacks for sound states.
 	/** Template class for implementing callbacks which can be attached to sounds.
 	@remarks
-		Allows member functions to be used as callbacks. Amended from OgreAL, 
-		originally written by CaseyB.
+		Allows member functions to be used as callbacks.
+		Amended from OgreAL, originally written by CaseyB.
 	**/
 	class _OGGSOUND_EXPORT OOSCallback
 	{

--- a/oggsound/include/OgreOggSoundFactory.h
+++ b/oggsound/include/OgreOggSoundFactory.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundFactory.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 	 
 *
-* @section DESCRIPTION
-* 
-* Factory manager for creation of sound objects
+* DESCRIPTION: Factory manager for creation of sound objects
 */
 
 #ifndef __OGREOGGSOUNDFactory_H__

--- a/oggsound/include/OgreOggSoundManager.h
+++ b/oggsound/include/OgreOggSoundManager.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundManager.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE.  
 *
-* @section DESCRIPTION
-* 
-* Manages the audio library
+* DESCRIPTION: Manages the audio library
 */
 
 #pragma once
@@ -138,8 +134,10 @@ namespace OgreOggSound
 				maximum number of sources to allocate (optional)
 			@param queueListSize
 				Desired size of queue list (optional | Multi-threaded ONLY)
+			@param scnMgr
+				SceneManager to use in order create sounds (If no manager specified, uses the first one)
 		 */
-		bool init(const std::string &deviceName = "", unsigned int maxSources=100, unsigned int queueListSize=100, Ogre::SceneManager* sMan=0);
+		bool init(const std::string &deviceName = "", unsigned int maxSources=100, unsigned int queueListSize=100, Ogre::SceneManager* scnMgr=0);
 		/** Gets the OpenAL device pointer
 		*/
 		const ALCdevice* getOpenalDevice() { return mDevice; }
@@ -172,7 +170,7 @@ namespace OgreOggSound
 			@param name 
 				Unique name of sound
 			@param file 
-				Audio file path string or "BUFFER" for memory buffer sound (@ref OgreBufferStreamSound)
+				Audio file path string or "BUFFER" for memory buffer sound (@ref OgreOggStreamBufferSound)
 			@param stream 
 				Flag indicating if the sound sound be streamed.
 			@param loop 
@@ -181,9 +179,9 @@ namespace OgreOggSound
 				Flag indicating if a source should be attached at creation.
 			@param scnMgr
 				Pointer to SceneManager this sound belongs - 0 defaults to first SceneManager defined.
-			@param immediately
-				Optional flag to indicate creation should occur immediately and not be passed to background thread
-				for queueing. Can be used to overcome the random creation time which might not be acceptable (MULTI-THREADED ONLY)
+			@param immediate
+				Optional flag to indicate creation should occur immediately and not be passed to background thread for queueing.
+				Can be used to overcome the random creation time which might not be acceptable (MULTI-THREADED ONLY)
 		 */
 		OgreOggISound* createSound(const std::string& name,const std::string& file, bool stream = false, bool loop = false, bool preBuffer=false, Ogre::SceneManager* scnMgr=0, bool immediate=false);
 		/** Gets a named sound.
@@ -311,6 +309,8 @@ namespace OgreOggSound
 				Name of audio file
 			@param buffer
 				OpenAL buffer ID holding audio data
+			@param parent
+				Sound from where to copy the properties: Buffers, PlayTime, Format
 		 */
 		bool _registerSharedBuffer(const Ogre::String& sName, ALuint& buffer, OgreOggISound* parent=0);
 		/** Sets distance model.
@@ -744,13 +744,16 @@ namespace OgreOggSound
 			@param name 
 				Unique name of sound
 			@param file 
-				Audio file path string or "BUFFER" for memory buffer sound (@ref OgreBufferStreamSound)
+				Audio file path string or "BUFFER" for memory buffer sound (@ref OgreOggStreamBufferSound)
 			@param stream 
 				Flag indicating if the sound sound be streamed.
 			@param loop 
 				Flag indicating if the file should loop.
 			@param preBuffer 
 				Flag indicating if a source should be attached at creation.
+			@param immediate
+				Optional flag to indicate creation should occur immediately and not be passed to background thread for queueing.
+				Can be used to overcome the random creation time which might not be acceptable (MULTI-THREADED ONLY)
 		 */
 		
 		OgreOggISound* _createSoundImpl(

--- a/oggsound/include/OgreOggSoundPlugin.h
+++ b/oggsound/include/OgreOggSoundPlugin.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundPlugin.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 
 *
-* @section DESCRIPTION
-* 
-* Impements the plugin interface for OGRE
+* DESCRIPTION: Impements the plugin interface for OGRE
 */
 
 #ifndef __OGREOGGSOUNDPlugin_H__
@@ -41,10 +37,8 @@
 #include "OgreOggSound.h"
 #include "OgreOggSoundFactory.h"
 
-
 namespace OgreOggSound
 {
-
 	//! Plugin instance for the MovableText 
 	class OgreOggSoundPlugin : public Ogre::Plugin
 	{
@@ -53,27 +47,43 @@ namespace OgreOggSound
 
 		OgreOggSoundPlugin();
 
-		/// @copydoc Plugin::getName
+        /** Get the name of the plugin.
+        @remarks An implementation must be supplied for this method to uniquely identify the plugin.
+        */
 		const Ogre::String& getName() const;
 
-		/// @copydoc Plugin::install
+		/** Perform the plugin initial installation sequence.
+		@remarks An implementation must be supplied for this method.
+		It must perform the startup tasks necessary to install any rendersystem customisations or anything else that is not dependent on system initialisation, ie only dependent on the core of Ogre.
+		It must not perform any operations that would create rendersystem-specific objects at this stage, that should be done in initialise().
+		*/
 		void install();
 
-		/// @copydoc Plugin::initialise
+		/** Perform any tasks the plugin needs to perform on full system initialisation.
+		@remarks An implementation must be supplied for this method.
+			It is called just after the system is fully initialised (either after Root::initialise if a window is created then, or after the first window is created)
+			and therefore all rendersystem functionality is available at this time. You can use this hook to create any resources which are dependent on a rendersystem or have rendersystem-specific implementations.
+        */
 		void initialise();
 
-		/// @copydoc Plugin::shutdown
+		/** Perform any tasks the plugin needs to perform when the system is shut down.
+		@remarks An implementation must be supplied for this method.
+		This method is called just before key parts of the system are unloaded, such as rendersystems being shut down.
+		You should use this hook to free up  resources and decouple custom objects from the OGRE system, whilst all the instances of other plugins (e.g. rendersystems) still exist.
+		*/
 		void shutdown();
 
-		/// @copydoc Plugin::uninstall
+		/** Perform the final plugin uninstallation sequence.
+		@remarks An implementation must be supplied for this method.
+		It must perform the cleanup tasks which haven't already been performed in shutdown() (e.g. final deletion of custom instances, if you kept them around incase the system was reinitialised).
+		At this stage you cannot be sure what other plugins are still loaded or active.
+		It must therefore not perform any operations that would reference any rendersystem-specific objects - those should have been sorted out in the 'shutdown' method.
+		*/
 		void uninstall();
 
 	protected:
-
 		OgreOggSoundFactory* mOgreOggSoundFactory;
 		OgreOggSoundManager* mOgreOggSoundManager;
-
-
 	};
 }
 

--- a/oggsound/include/OgreOggSoundPrereqs.h
+++ b/oggsound/include/OgreOggSoundPrereqs.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundPrereqs.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 
 *
-* @section DESCRIPTION
-* 
-* Pre-requisites for building lib
+* DESCRIPTION: Pre-requisites for building the library
 */
 #pragma once 
 

--- a/oggsound/include/OgreOggSoundRecord.h
+++ b/oggsound/include/OgreOggSoundRecord.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundRecord.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 
 *
-* @section DESCRIPTION
-* 
-* Implements methods for recording audio 
+* DESCRIPTION: Implements methods for recording audio
 */
 
 #pragma once
@@ -110,8 +106,7 @@ namespace OgreOggSound
 		void _updateRecording();
 		/** Initialises a capture device ready to record audio data
 		@remarks
-		Gets a list of capture devices, initialises one, and opens output file
-		for writing to.
+		Gets a list of capture devices, initialises one, and opens output file for writing to.
 		*/
 		bool _openDevice();
 

--- a/oggsound/include/OgreOggStaticSound.h
+++ b/oggsound/include/OgreOggStaticSound.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStaticSound.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE.  
 *
-* @section DESCRIPTION
-* 
-* Implements methods for creating/using a static ogg sound
+* DESCRIPTION: Implements methods for creating/using a static ogg sound
 */
 
 #pragma once
@@ -80,6 +76,12 @@ namespace OgreOggSound
 
 		/**
 		 * Constructor
+		@remarks
+			Creates a static sound object for playing audio from an OGG file.
+			@param name
+				Unique name for sound.
+			@param scnMgr
+				SceneManager which created this sound (if the sound was created through the plugin method createMovableobject()).
 		 */
 		OgreOggStaticSound(
 			const Ogre::String& name, Ogre::SceneManager* scnMgr
@@ -98,23 +100,25 @@ namespace OgreOggSound
 		void release();	
 		/** Opens audio file.
 		@remarks
-			Opens a specified file and checks validity. Reads first chunks
-			of audio data into buffers.
-			@param
-				file path string
+			Opens a specified file and checks validity.
+			Reads first chunks of audio data into buffers.
+			@param fileStream
+				file stream pointer
 		 */
 		void _openImpl(Ogre::DataStreamPtr& fileStream);
 		/** Opens audio file.
 		@remarks
 			Uses a shared buffer.
+			@param fName
+				audio file name
 			@param buffer
 				shared buffer reference
 		 */
 		void _openImpl(const Ogre::String& fName, sharedAudioBuffer* buffer);
 		/** Stops playing sound.
 		@remarks
-			Stops playing audio immediately. If specified to do so its source
-			will be released also.
+			Stops playing audio immediately.
+			If specified to do so its source will be released also.
 		*/
 		void _stopImpl();
 		/** Pauses sound.
@@ -124,9 +128,8 @@ namespace OgreOggSound
 		void _pauseImpl();
 		/** Plays the sound.
 		@remarks
-			Begins playback of all buffers queued on the source. If a
-			source hasn't been setup yet it is requested and initialised
-			within this call.
+			Begins playback of all buffers queued on the source.
+			If a source hasn't been setup yet it is requested and initialised within this call.
 		 */
 		void _playImpl();
 		/** Updates the data buffers with sound information.

--- a/oggsound/include/OgreOggStaticWavSound.h
+++ b/oggsound/include/OgreOggStaticWavSound.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStaticWavSound.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE.  
 *
-* @section DESCRIPTION
-* 
-* Implements methods for creating/using a static wav sound
+* DESCRIPTION: Implements methods for creating/using a static wav sound
 */
 
 #pragma once
@@ -80,6 +76,12 @@ namespace OgreOggSound
 
 		/**
 		 * Constructor
+		@remarks
+			Creates a static sound object for playing audio from a WAV file.
+			@param name
+				Unique name for sound.
+			@param scnMgr
+				SceneManager which created this sound (if the sound was created through the plugin method createMovableobject()).
 		 */
 		OgreOggStaticWavSound(
 			const Ogre::String& name, Ogre::SceneManager* scnMgr
@@ -98,15 +100,17 @@ namespace OgreOggSound
 		void release();	
 		/** Opens audio file.
 		@remarks
-			Opens a specified file and checks validity. Reads first chunks
-			of audio data into buffers.
-			@param
-				file path string
+			Opens a specified file and checks validity.
+			Reads first chunks of audio data into buffers.
+			@param fileStream
+				file stream pointer
 		 */
 		void _openImpl(Ogre::DataStreamPtr& fileStream);
 		/** Opens audio file.
 		@remarks
 			Uses a shared buffer.
+			@param fName
+				audio file name
 			@param buffer
 				shared buffer reference
 		 */

--- a/oggsound/include/OgreOggStreamBufferSound.h
+++ b/oggsound/include/OgreOggStreamBufferSound.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStreamBufferSound.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 
 *
-* @section DESCRIPTION
-* 
-* Implements methods for creating/using a streamed ogg sound
+* DESCRIPTION: Implements methods for creating/using a streamed ogg sound
 */
 
 #pragma once
@@ -78,10 +74,11 @@ namespace OgreOggSound
 
 		/** Constructor
 		@remarks
-			Creates a streamed sound object for playing audio directly from
-			a file stream.
-			@param
-				name Unique name for sound.	
+			Creates a streamed sound object for playing audio directly from a file stream.
+			@param name
+				Unique name for sound.
+			@param scnMgr
+				SceneManager which created this sound (if the sound was created through the plugin method createMovableobject()).
 		 */
 		OgreOggStreamBufferSound(
 			const Ogre::String& name, Ogre::SceneManager* scnMgr
@@ -95,10 +92,10 @@ namespace OgreOggSound
 		~OgreOggStreamBufferSound();
 		/** Opens audio file.
 		@remarks
-			Opens a specified file and checks validity. Reads first chunks
-			of audio data into buffers.
-			@param
-				file path string
+			Opens a specified file and checks validity.
+			Reads first chunks of audio data into buffers.
+			@param fileStream
+				file stream pointer
 		 */
 		void _openImpl(Ogre::DataStreamPtr& fileStream) {}
 		/** Stops playing sound.

--- a/oggsound/include/OgreOggStreamSound.h
+++ b/oggsound/include/OgreOggStreamSound.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStreamSound.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 
 *
-* @section DESCRIPTION
-* 
-* Implements methods for creating/using a streamed ogg sound
+* DESCRIPTION: Implements methods for creating/using a streamed ogg sound
 */
 
 #pragma once
@@ -87,10 +83,11 @@ namespace OgreOggSound
 
 		/** Constructor
 		@remarks
-			Creates a streamed sound object for playing audio directly from
-			a file stream.
-			@param
-				name Unique name for sound.	
+			Creates a streamed sound object for playing audio directly from a file stream.
+			@param name
+				Unique name for sound.
+			@param scnMgr
+				SceneManager which created this sound (if the sound was created through the plugin method createMovableobject()).
 		 */
 		OgreOggStreamSound(
 			const Ogre::String& name, Ogre::SceneManager* scnMgr
@@ -111,8 +108,8 @@ namespace OgreOggSound
 		@remarks
 			Opens a specified file and checks validity. Reads first chunks
 			of audio data into buffers.
-			@param
-				file path string
+			@param fileStream
+				file stream pointer
 		 */
 		void _openImpl(Ogre::DataStreamPtr& fileStream);
 		/** Stops playing sound.

--- a/oggsound/include/OgreOggStreamWavSound.h
+++ b/oggsound/include/OgreOggStreamWavSound.h
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStreamWavSound.h
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -28,9 +26,7 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE. 
 *
-* @section DESCRIPTION
-* 
-* Implements methods for creating/using a streamed wav sound
+* DESCRIPTION: Implements methods for creating/using a streamed wav sound
 */
 
 #pragma once
@@ -85,10 +81,11 @@ namespace OgreOggSound
 
 		/** Constructor
 		@remarks
-			Creates a streamed sound object for playing audio directly from
-			a file stream.
-			@param
-				name Unique name for sound.	
+			Creates a streamed sound object for playing audio directly from a WAV file stream.
+			@param name
+				Unique name for sound.
+			@param scnMgr
+				SceneManager which created this sound (if the sound was created through the plugin method createMovableobject()).
 		 */
 		OgreOggStreamWavSound(
 			const Ogre::String& name, Ogre::SceneManager* scnMgr
@@ -109,8 +106,8 @@ namespace OgreOggSound
 		@remarks
 			Opens a specified file and checks validity. Reads first chunks
 			of audio data into buffers.
-			@param
-				file path string
+			@param fileStream
+				file stream pointer
 		 */
 		void _openImpl(Ogre::DataStreamPtr& fileStream);
 		/** Stops playing sound.

--- a/oggsound/src/OgreOggISound.cpp
+++ b/oggsound/src/OgreOggISound.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggISound.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -114,7 +112,7 @@ namespace OgreOggSound
 	,mPlayPosChanged(false)  
 	,mPlayPos(0.f) 
 	,mPriority(0)
-	,mScnMan(scnMgr)
+	,mScnMgr(scnMgr)
 	,mAudioOffset(0)
 	,mAudioEnd(0)
 	,mLoopOffset(0)

--- a/oggsound/src/OgreOggListener.cpp
+++ b/oggsound/src/OgreOggListener.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggListener.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggSoundFactory.cpp
+++ b/oggsound/src/OgreOggSoundFactory.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundFactory.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggSoundManager.cpp
+++ b/oggsound/src/OgreOggSoundManager.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundManager.cpp
 * @author  Ian Stangoe 
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 *
 * This source file is part of OgreOggSound, an OpenAL wrapper library for
 * use with the Ogre Rendering Engine.
 *
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +47,7 @@ namespace OgreOggSound
 {
 	using namespace Ogre;
 
-	const Ogre::String OgreOggSoundManager::OGREOGGSOUND_VERSION_STRING = "OgreOggSound v1.26";
+	const Ogre::String OgreOggSoundManager::OGREOGGSOUND_VERSION_STRING = "OgreOggSound v1.28";
 
 	/*/////////////////////////////////////////////////////////////////*/
 	OgreOggSoundManager::OgreOggSoundManager() :

--- a/oggsound/src/OgreOggSoundPlugin.cpp
+++ b/oggsound/src/OgreOggSoundPlugin.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundPlugin.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggSoundPluginDllStart.cpp
+++ b/oggsound/src/OgreOggSoundPluginDllStart.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundPluginDllStart.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggSoundRecord.cpp
+++ b/oggsound/src/OgreOggSoundRecord.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggSoundRecord.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggStaticSound.cpp
+++ b/oggsound/src/OgreOggStaticSound.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStaticSound.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggStaticWavSound.cpp
+++ b/oggsound/src/OgreOggStaticWavSound.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStaticWavSound.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggStreamBufferSound.cpp
+++ b/oggsound/src/OgreOggStreamBufferSound.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStreamBufferSound.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggStreamSound.cpp
+++ b/oggsound/src/OgreOggStreamSound.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStreamSound.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/oggsound/src/OgreOggStreamWavSound.cpp
+++ b/oggsound/src/OgreOggStreamWavSound.cpp
@@ -1,14 +1,12 @@
 /**
-* @file OgreOggStreamWavSound.cpp
 * @author  Ian Stangoe
-* @version v1.26
 *
-* @section LICENSE
+* LICENSE:
 * 
 * This source file is part of OgreOggSound, an OpenAL wrapper library for   
 * use with the Ogre Rendering Engine.										 
 *                                                                           
-* Copyright (c) 2013 Ian Stangoe
+* Copyright (c) 2017 Ian Stangoe
 *
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal

--- a/scripts/Doxyfile.in
+++ b/scripts/Doxyfile.in
@@ -31,7 +31,6 @@ SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
 QT_AUTOBRIEF           = NO
 MULTILINE_CPP_IS_BRIEF = NO
-DETAILS_AT_TOP         = NO
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 8
@@ -76,7 +75,6 @@ GENERATE_DEPRECATEDLIST= YES
 ENABLED_SECTIONS       = 
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = YES
-SHOW_DIRECTORIES       = NO
 SHOW_FILES             = NO
 SHOW_NAMESPACES        = YES
 FILE_VERSION_FILTER    = 
@@ -191,7 +189,7 @@ LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
 COMPACT_LATEX          = NO
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 EXTRA_PACKAGES         = 
 LATEX_HEADER           = 
 PDF_HYPERLINKS         = YES
@@ -250,12 +248,10 @@ TAGFILES               = ${OGRE_CONFIG_DIR}/docs/api/Ogre.tag=https://ogrecave.g
 GENERATE_TAGFILE       = 
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
-PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool   
 #---------------------------------------------------------------------------
 CLASS_DIAGRAMS         = NO
-MSCGEN_PATH            = 
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = YES
 DOT_FONTNAME           = 

--- a/theoravideo/include/OgreVideoManager.h
+++ b/theoravideo/include/OgreVideoManager.h
@@ -40,7 +40,9 @@ namespace Ogre
 				All setting should have been set before calling this.
 				Refer to base class ( ExternalTextureSource ) for details
 			@param material_name
-				Material  you are attaching a movie to.
+				Material you are attaching a movie to.
+			@param group_name
+				Resource group where the texture is registered
 		*/
 		void createDefinedTexture(const String& material_name,
 								  const String& group_name = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
@@ -51,7 +53,11 @@ namespace Ogre
 			@param video_file_name
 				Video input file name.
 			@param material_name
-				Material  you are attaching a movie to.
+				Material you are attaching a movie to.
+			@param video_group_name
+				Resource group where the video file is registered
+			@param group_name
+				Resource group where the texture is registered
 		*/
 		TheoraVideoClip* createVideoTexture(const String& video_file_name, const String& material_name,
 											const String& video_group_name = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME,
@@ -63,9 +69,11 @@ namespace Ogre
 				you should use destroyVideoClip()
 			@param material_name
 				Material Name you are looking to remove a video clip from
+			@param group_name
+				Resource group where the texture is registered
 		*/
 		void destroyAdvancedTexture(const String& material_name,
-									const String& groupName = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
+									const String& group_name = ResourceGroupManager::DEFAULT_RESOURCE_GROUP_NAME);
 		
 		/// destroy all video textures
 		void destroyAllVideoTextures();

--- a/theoravideo/src/OgreVideoManager.cpp
+++ b/theoravideo/src/OgreVideoManager.cpp
@@ -141,7 +141,7 @@ namespace Ogre
 		return clip;
 	}
 
-	void OgreVideoManager::destroyAdvancedTexture(const String& material_name,const String& groupName)
+	void OgreVideoManager::destroyAdvancedTexture(const String& material_name,const String& group_name)
 	{
 		logMessage("Destroying ogg_video texture on material: "+material_name);
 		


### PR DESCRIPTION
 - Update version to 1.28 and copyright year to 2017 (as last version from sourceforge)
 - Fix most warnings from Doxygen (about missing parameters / wrong references)
