### PR TITLE
Improve log messaging consistency and use logError where appropiate

### DIFF
--- a/oggsound/include/OgreOggSoundFactory.h
+++ b/oggsound/include/OgreOggSoundFactory.h
@@ -35,7 +35,7 @@
 #include <Ogre.h>
 #include "OgreOggSound.h"
 
-namespace OgreOggSound 
+namespace OgreOggSound
 {
 	//! MovableFactory for creating Sound instances 
 	class _OGGSOUND_EXPORT OgreOggSoundFactory : public Ogre::MovableObjectFactory
@@ -56,7 +56,6 @@ namespace OgreOggSound
 		static Ogre::String FACTORY_TYPE_NAME;
 
 		const Ogre::String& getType(void) const;
-
 	};
 }
 

--- a/oggsound/include/OgreOggSoundManager.h
+++ b/oggsound/include/OgreOggSoundManager.h
@@ -37,12 +37,11 @@
 #include "LocklessQueue.h"
 
 #include <map>
-#include <string>
 
 namespace OgreOggSound
 {
-	typedef std::map<std::string, OgreOggISound*> SoundMap;
-	typedef std::map<std::string, ALuint> EffectList;
+	typedef std::map<Ogre::String, OgreOggISound*> SoundMap;
+	typedef std::map<Ogre::String, ALuint> EffectList;
 	typedef std::map<ALenum, bool> FeatureList;
 	typedef std::list<OgreOggISound*> ActiveList;
 	typedef std::deque<ALuint> SourceList;
@@ -183,14 +182,14 @@ namespace OgreOggSound
 				Optional flag to indicate creation should occur immediately and not be passed to background thread for queueing.
 				Can be used to overcome the random creation time which might not be acceptable (MULTI-THREADED ONLY)
 		 */
-		OgreOggISound* createSound(const std::string& name,const std::string& file, bool stream = false, bool loop = false, bool preBuffer=false, Ogre::SceneManager* scnMgr=0, bool immediate=false);
+		OgreOggISound* createSound(const Ogre::String& name,const Ogre::String& file, bool stream = false, bool loop = false, bool preBuffer=false, Ogre::SceneManager* scnMgr=0, bool immediate=false);
 		/** Gets a named sound.
 		@remarks
 			Returns a named sound object if defined, NULL otherwise.
 			@param name 
 				Sound name.
 		 */
-		OgreOggISound *getSound(const std::string& name);
+		OgreOggISound *getSound(const Ogre::String& name);
 		/** Gets list of created sounds.
 		@remarks
 			Returns a vector of sound name strings.
@@ -202,7 +201,7 @@ namespace OgreOggSound
 			@param name 
 				Sound name.
 		 */
-		bool hasSound(const std::string& name);
+		bool hasSound(const Ogre::String& name);
 		/** Sets the pitch of all sounds.
 		@remarks
 			Sets the pitch modifier applied to all sounds.
@@ -244,7 +243,7 @@ namespace OgreOggSound
 			@param name
 				Sound name to destroy.
 		 */
-		void destroySound(const std::string& name="");
+		void destroySound(const Ogre::String& name="");
 		/** Destroys a single sound.
 		@remarks
 			Destroys a single sound object.
@@ -434,7 +433,7 @@ namespace OgreOggSound
 			@param lfGain
 				desired gain for filtered low frequencies (only affects highpass and bandpass filters). Range: [0.0, 1.0]
 		 */
-		bool createEFXFilter(const std::string& eName, ALint type, ALfloat gain=1.0, ALfloat hfGain=1.0, ALfloat lfGain=1.0);
+		bool createEFXFilter(const Ogre::String& eName, ALint type, ALfloat gain=1.0, ALfloat hfGain=1.0, ALfloat lfGain=1.0);
 		/** Creates a specified EFX effect
 		@remarks
 			Creates a specified EFX effect if hardware supports it.
@@ -448,9 +447,9 @@ namespace OgreOggSound
 				legacy structure describing a preset reverb effect. (See efx-presets.h)
 		 */
 #	if HAVE_EFX == 1
-		bool createEFXEffect(const std::string& eName, ALint type, EAXREVERBPROPERTIES* props=0);
+		bool createEFXEffect(const Ogre::String& eName, ALint type, EAXREVERBPROPERTIES* props=0);
 #	elif HAVE_EFX == 2
-		bool createEFXEffect(const std::string& eName, ALint type, EFXEAXREVERBPROPERTIES* props=0);
+		bool createEFXEffect(const Ogre::String& eName, ALint type, EFXEAXREVERBPROPERTIES* props=0);
 #	endif
 		/** Sets extended properties on a specified sounds source
 		@remarks
@@ -464,7 +463,7 @@ namespace OgreOggSound
 			@param coneOuterHF 
 				cone outer gain factor for High frequencies.
 		 */
-		bool setEFXSoundProperties(const std::string& sName, float airAbsorption=0.f, float roomRolloff=0.f, float coneOuterHF=0.f);
+		bool setEFXSoundProperties(const Ogre::String& sName, float airAbsorption=0.f, float roomRolloff=0.f, float coneOuterHF=0.f);
 		/** Sets extended properties on a specified sounds source
 		@remarks
 			Tries to set EFX extended source properties.
@@ -491,7 +490,7 @@ namespace OgreOggSound
 			@param param 
 				float value to set.
 		 */
-		bool setEFXEffectParameter(const std::string& eName, ALint effectType, ALenum attrib, ALfloat param);
+		bool setEFXEffectParameter(const Ogre::String& eName, ALint effectType, ALenum attrib, ALfloat param);
 		/** Sets a specified paremeter on an effect
 		@remarks
 			Tries to set a parameter value on a specified effect.
@@ -505,7 +504,7 @@ namespace OgreOggSound
 			@param params 
 				vector pointer of float values to set.
 		 */
-		bool setEFXEffectParameter(const std::string& eName, ALint type, ALenum attrib, ALfloat* params=0);
+		bool setEFXEffectParameter(const Ogre::String& eName, ALint type, ALenum attrib, ALfloat* params=0);
 		/** Sets a specified paremeter on an effect
 		@remarks
 			Tries to set a parameter value on a specified effect.
@@ -519,7 +518,7 @@ namespace OgreOggSound
 			@param param 
 				integer value to set.
 		 */
-		bool setEFXEffectParameter(const std::string& eName, ALint type, ALenum attrib, ALint param);
+		bool setEFXEffectParameter(const Ogre::String& eName, ALint type, ALenum attrib, ALint param);
 		/** Sets a specified paremeter on an effect
 		@remarks
 			Tries to set a parameter value on a specified effect.
@@ -533,7 +532,7 @@ namespace OgreOggSound
 			@param params 
 				vector pointer of integer values to set.
 		 */
-		bool setEFXEffectParameter(const std::string& eName, ALint type, ALenum attrib, ALint* params=0);
+		bool setEFXEffectParameter(const Ogre::String& eName, ALint type, ALenum attrib, ALint* params=0);
 		/** Gets the maximum number of Auxiliary Effect Slots detected for the OpenAL device on initialization
 		@remarks
 			Returns how many simultaneous effects can be applied at the same time to the Output Mix.
@@ -566,7 +565,7 @@ namespace OgreOggSound
 			@param filter 
 				name of filter as defined when created
 		 */
-		bool attachEffectToSound(const std::string& sName, ALuint slot, const Ogre::String& effect="", const Ogre::String& filter="");
+		bool attachEffectToSound(const Ogre::String& sName, ALuint slot, const Ogre::String& effect="", const Ogre::String& filter="");
 		/** Attaches a filter to a sound
 		@remarks
 			Currently sound must have a source attached prior to this call. (Does nothing without EAX or EFX support)
@@ -575,7 +574,7 @@ namespace OgreOggSound
 			@param filter 
 				name of filter as defined when created
 		 */
-		bool attachFilterToSound(const std::string& sName, const Ogre::String& filter="");
+		bool attachFilterToSound(const Ogre::String& sName, const Ogre::String& filter="");
 		/** Detaches all effects from a sound
 		@remarks
 			Currently sound must have a source attached prior to this call. (Does nothing without EAX or EFX support)
@@ -584,14 +583,14 @@ namespace OgreOggSound
 			@param slotID 
 				slot ID
 		 */
-		bool detachEffectFromSound(const std::string& sName, ALuint slotID);
+		bool detachEffectFromSound(const Ogre::String& sName, ALuint slotID);
 		/** Detaches all filters from a sound
 		@remarks
 			Currently sound must have a source attached prior to this call.
 			@param sName 
 				name of sound
 		 */
-		bool detachFilterFromSound(const std::string& sName);
+		bool detachFilterFromSound(const Ogre::String& sName);
 		/** Attaches an effect to a sound
 		@remarks
 			Currently sound must have a source attached prior to this call.
@@ -638,15 +637,15 @@ namespace OgreOggSound
 #endif
 
 #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
+		/** Creates recording class to manage device recording
+		 */
 		OgreOggSoundRecord* createRecorder();
-		/** Gets recording device
+		/** Gets recording class created to manage device recording
 		 */
 		OgreOggSoundRecord* getRecorder() { return mRecorder; }
 		/** Returns whether a capture device is available
 		 */
 		bool isRecordingAvailable() const;
-		/** Creates a recordable object
-		 */
 #endif
 
 #if OGGSOUND_THREADED
@@ -758,11 +757,11 @@ namespace OgreOggSound
 		
 		OgreOggISound* _createSoundImpl(
 			Ogre::SceneManager* scnMgr,
-			const std::string& name,
+			const Ogre::String& name,
 			#if OGRE_VERSION_MAJOR == 2
 			Ogre::IdType id,
 			#endif
-			const std::string& file,
+			const Ogre::String& file,
 			bool stream    = false,
 			bool loop      = false,
 			bool preBuffer = false,
@@ -861,12 +860,12 @@ namespace OgreOggSound
 		@param fName 
 			name of filter as defined when created.
 		 */
-		ALuint _getEFXFilter(const std::string& fName);
+		ALuint _getEFXFilter(const Ogre::String& fName);
 		/** Gets a specified EFX Effect
 		@param eName 
 			name of effect as defined when created.
 		 */
-		ALuint _getEFXEffect(const std::string& eName);
+		ALuint _getEFXEffect(const Ogre::String& eName);
 		/** Gets a specified EFX Effect slot
 		@param slotID 
 			index of auxiliary effect slot

--- a/oggsound/include/OgreOggSoundPlugin.h
+++ b/oggsound/include/OgreOggSoundPlugin.h
@@ -42,9 +42,7 @@ namespace OgreOggSound
 	//! Plugin instance for the MovableText 
 	class OgreOggSoundPlugin : public Ogre::Plugin
 	{
-
 	public:
-
 		OgreOggSoundPlugin();
 
         /** Get the name of the plugin.

--- a/oggsound/include/OgreOggSoundRecord.h
+++ b/oggsound/include/OgreOggSoundRecord.h
@@ -68,9 +68,10 @@ namespace OgreOggSound
 	//! Captures audio data
 	/**
 	@remarks
-		This class can be used to capture audio data to an external file, WAV file ONLY.
-		Use control panel --> Sound and Audio devices applet to select input type and volume.
-		NOTE:- default file properties are - Frequency: 44.1Khz, Format: 16-bit stereo, Buffer Size: 8820 bytes.
+		This class can be used to capture audio data to an external file, WAV file ONLY.\n
+		Use control panel --> Sound and Audio devices applet to select input type and volume.\n
+		This class shoud be instantiated by using the OgreOggSound::OgreOggSoundManager::createRecorder() function.\n
+		NOTE: Default file properties are - Frequency: 44.1Khz, Format: 16-bit stereo, Buffer Size: 8820 bytes.
 	*/
 	class _OGGSOUND_EXPORT OgreOggSoundRecord
 	{

--- a/oggsound/src/OgreOggISound.cpp
+++ b/oggsound/src/OgreOggISound.cpp
@@ -607,7 +607,7 @@ namespace OgreOggSound
 		alSourcef(mSource, AL_SEC_OFFSET, mPlayPos);
 		if (alGetError())
 		{
-			Ogre::LogManager::getSingleton().logMessage("***--- OgreOggISound::_recoverPlayPosition() - Unable to set play position", Ogre::LML_CRITICAL);
+			Ogre::LogManager::getSingleton().logError("*** OgreOggISound::_recoverPlayPosition() - Unable to set play position");
 		}
 	}
 	/*/////////////////////////////////////////////////////////////////*/
@@ -631,7 +631,7 @@ namespace OgreOggSound
 			alSourcef(mSource, AL_SEC_OFFSET, seconds);
 			if (alGetError())
 			{
-				Ogre::LogManager::getSingleton().logMessage("***--- OgreOggISound::setPlayPosition() - Error setting play position", Ogre::LML_CRITICAL);
+				Ogre::LogManager::getSingleton().logError("*** OgreOggISound::setPlayPosition() - Error setting play position");
 			}
 			// Reset flag
 			mPlayPosChanged = false;
@@ -656,7 +656,7 @@ namespace OgreOggSound
 		alGetSourcef(mSource, AL_SEC_OFFSET, &offset);
 		if (alGetError())
 		{
-			Ogre::LogManager::getSingleton().logMessage("***--- OgreOggISound::setPlayPosition() - Error getting play position", Ogre::LML_CRITICAL);
+			Ogre::LogManager::getSingleton().logError("*** OgreOggISound::setPlayPosition() - Error getting play position");
 			return -1.f;
 		}
 			

--- a/oggsound/src/OgreOggSoundFactory.cpp
+++ b/oggsound/src/OgreOggSoundFactory.cpp
@@ -33,102 +33,103 @@
 #include "OgreOggSound.h"
 #include "OgreOggSoundFactory.h"
 
-using namespace Ogre;
-using namespace OgreOggSound;
+namespace OgreOggSound
+{
+	Ogre::String OgreOggSoundFactory::FACTORY_TYPE_NAME = "OgreOggISound";
 
-String OgreOggSoundFactory::FACTORY_TYPE_NAME = "OgreOggISound";
-//-----------------------------------------------------------------------
-const String& OgreOggSoundFactory::getType(void) const
-{
-	return FACTORY_TYPE_NAME;
-}
-//-----------------------------------------------------------------------
-#if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR == 0
-MovableObject* OgreOggSoundFactory::createInstanceImpl(IdType id, ObjectMemoryManager *objectMemoryManager, const NameValuePairList* params)
-#elif OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR > 0
-MovableObject* OgreOggSoundFactory::createInstanceImpl(IdType id, ObjectMemoryManager *objectMemoryManager, SceneManager* manager, const NameValuePairList* params)
-#else
-MovableObject* OgreOggSoundFactory::createInstanceImpl(const String& name, const NameValuePairList* params)
-#endif
-{
-	String fileName;
-	#if OGRE_VERSION_MAJOR == 2
-	String reName = BLANKSTRING;
-	#else
-	String reName = name;
-	#endif
-	
-	if (params != 0)
+	//-----------------------------------------------------------------------
+	const Ogre::String& OgreOggSoundFactory::getType(void) const
 	{
-		bool loop = false;
-		bool stream = false;
-		bool preBuffer = false;
-		bool immediate = false;
-		SceneManager* scnMgr = 0;
-
-		NameValuePairList::const_iterator fileNameIterator = params->find("fileName");
-		if (fileNameIterator != params->end())
-		{
-			// Get filename
-			fileName = fileNameIterator->second;
-		}
-
-		NameValuePairList::const_iterator loopIterator = params->find("loop");
-		if (loopIterator != params->end())
-		{
-			// Get loop setting
-			loop = StringUtil::match(loopIterator->second,"true",false);
-		}
-
-		NameValuePairList::const_iterator streamIterator = params->find("stream");
-		if (streamIterator != params->end())
-		{
-			// Get stream flag
-			stream = StringUtil::match(streamIterator->second,"true",false);
-		}
-
-		NameValuePairList::const_iterator preBufferIterator = params->find("preBuffer");
-		if (preBufferIterator != params->end())
-		{
-			// Get prebuffer flag
-			preBuffer = StringUtil::match(preBufferIterator->second,"true",false);
-		}
-
-		NameValuePairList::const_iterator immediateIterator = params->find("immediate");
-		if (immediateIterator != params->end())
-		{
-			// Get prebuffer flag
-			immediate = StringUtil::match(immediateIterator->second,"true",false);
-		}
-
-		NameValuePairList::const_iterator sManIterator = params->find("sceneManagerName");
-		if (sManIterator != params->end())
-		{
-			// Get SceneManager name
-			scnMgr = Ogre::Root::getSingletonPtr()->getSceneManager(sManIterator->second);
-		}
-
-		NameValuePairList::const_iterator sNameIterator = params->find("name");
-		if (sNameIterator != params->end())
-		{
-			// Get sound name
-			reName = sNameIterator->second;
-		}
-		
-		// when no caption is set
-		if ( !scnMgr || reName == "" || fileName == "" )
-		{
-			OGRE_EXCEPT(Exception::ERR_INVALIDPARAMS,
-				"'name & fileName & sceneManagerName' parameters required when constructing an OgreOggISound.",
-				"OgreOggSoundFactory::createInstance");
-		}
-
-		#if OGRE_VERSION_MAJOR == 2
-		return OgreOggSoundManager::getSingletonPtr()->_createSoundImpl(scnMgr, reName, id, fileName, stream, loop, preBuffer, immediate);
-		#else
-		return OgreOggSoundManager::getSingletonPtr()->_createSoundImpl(scnMgr, reName, fileName, stream, loop, preBuffer, immediate);
-		#endif
+		return FACTORY_TYPE_NAME;
 	}
+	//-----------------------------------------------------------------------
+	#if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR == 0
+	Ogre::MovableObject* OgreOggSoundFactory::createInstanceImpl(IdType id, Ogre::ObjectMemoryManager *objectMemoryManager, const Ogre::NameValuePairList* params)
+	#elif OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR > 0
+	Ogre::MovableObject* OgreOggSoundFactory::createInstanceImpl(IdType id, Ogre::ObjectMemoryManager *objectMemoryManager, Ogre::SceneManager* manager, const Ogre::NameValuePairList* params)
+	#else
+	Ogre::MovableObject* OgreOggSoundFactory::createInstanceImpl(const Ogre::String& name, const Ogre::NameValuePairList* params)
+	#endif
+	{
+		Ogre::String fileName;
+		#if OGRE_VERSION_MAJOR == 2
+		Ogre::String reName = BLANKSTRING;
+		#else
+		Ogre::String reName = name;
+		#endif
 
-	return 0;
+		if (params != 0)
+		{
+			bool loop = false;
+			bool stream = false;
+			bool preBuffer = false;
+			bool immediate = false;
+			Ogre::SceneManager* scnMgr = 0;
+
+			Ogre::NameValuePairList::const_iterator fileNameIterator = params->find("fileName");
+			if (fileNameIterator != params->end())
+			{
+				// Get filename
+				fileName = fileNameIterator->second;
+			}
+
+			Ogre::NameValuePairList::const_iterator loopIterator = params->find("loop");
+			if (loopIterator != params->end())
+			{
+				// Get loop setting
+				loop = Ogre::StringUtil::match(loopIterator->second,"true",false);
+			}
+
+			Ogre::NameValuePairList::const_iterator streamIterator = params->find("stream");
+			if (streamIterator != params->end())
+			{
+				// Get stream flag
+				stream = Ogre::StringUtil::match(streamIterator->second,"true",false);
+			}
+
+			Ogre::NameValuePairList::const_iterator preBufferIterator = params->find("preBuffer");
+			if (preBufferIterator != params->end())
+			{
+				// Get prebuffer flag
+				preBuffer = Ogre::StringUtil::match(preBufferIterator->second,"true",false);
+			}
+
+			Ogre::NameValuePairList::const_iterator immediateIterator = params->find("immediate");
+			if (immediateIterator != params->end())
+			{
+				// Get prebuffer flag
+				immediate = Ogre::StringUtil::match(immediateIterator->second,"true",false);
+			}
+
+			Ogre::NameValuePairList::const_iterator sManIterator = params->find("sceneManagerName");
+			if (sManIterator != params->end())
+			{
+				// Get SceneManager name
+				scnMgr = Ogre::Root::getSingletonPtr()->getSceneManager(sManIterator->second);
+			}
+
+			Ogre::NameValuePairList::const_iterator sNameIterator = params->find("name");
+			if (sNameIterator != params->end())
+			{
+				// Get sound name
+				reName = sNameIterator->second;
+			}
+
+			// when no caption is set
+			if ( !scnMgr || reName == "" || fileName == "" )
+			{
+				OGRE_EXCEPT(Ogre::Exception::ERR_INVALIDPARAMS,
+					"'name & fileName & sceneManagerName' parameters required when constructing an OgreOggISound.",
+					"OgreOggSoundFactory::createInstance");
+			}
+
+			#if OGRE_VERSION_MAJOR == 2
+			return OgreOggSoundManager::getSingletonPtr()->_createSoundImpl(scnMgr, reName, id, fileName, stream, loop, preBuffer, immediate);
+			#else
+			return OgreOggSoundManager::getSingletonPtr()->_createSoundImpl(scnMgr, reName, fileName, stream, loop, preBuffer, immediate);
+			#endif
+		}
+
+		return 0;
+	}
 }

--- a/oggsound/src/OgreOggSoundManager.cpp
+++ b/oggsound/src/OgreOggSoundManager.cpp
@@ -45,8 +45,6 @@
 
 namespace OgreOggSound
 {
-	using namespace Ogre;
-
 	const Ogre::String OgreOggSoundManager::OGREOGGSOUND_VERSION_STRING = "OgreOggSound v1.28";
 
 	/*/////////////////////////////////////////////////////////////////*/
@@ -201,16 +199,16 @@ namespace OgreOggSound
 		_destroyListener();
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::init(	const std::string &deviceName, 
-									unsigned int maxSources, 
-									unsigned int queueListSize, 
-									SceneManager* scnMgr)
+	bool OgreOggSoundManager::init(	const Ogre::String &deviceName,
+									unsigned int maxSources,
+									unsigned int queueListSize,
+									Ogre::SceneManager* scnMgr)
 	{
 		if (mDevice) return true;
 
 		Ogre::LogManager::getSingleton().logMessage("*****************************************", Ogre::LML_NORMAL);
 		Ogre::LogManager::getSingleton().logMessage("*** --- Initialising OgreOggSound --- ***", Ogre::LML_NORMAL);
-		Ogre::LogManager::getSingleton().logMessage("*** ---     "+OGREOGGSOUND_VERSION_STRING+"    --- ***", Ogre::LML_NORMAL);
+		Ogre::LogManager::getSingleton().logMessage("*** ---     " + OGREOGGSOUND_VERSION_STRING + "    --- ***", Ogre::LML_NORMAL);
 		Ogre::LogManager::getSingleton().logMessage("*****************************************", Ogre::LML_NORMAL);
 
 		// Set source limit
@@ -233,13 +231,13 @@ namespace OgreOggSound
 		{
 			switch (error)
 			{
-			case AL_INVALID_NAME:		{ LogManager::getSingleton().logMessage("Invalid Name when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL); }		break;
-			case AL_INVALID_ENUM:		{ LogManager::getSingleton().logMessage("Invalid Enum when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL); }		break;
-			case AL_INVALID_VALUE:		{ LogManager::getSingleton().logMessage("Invalid Value when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL);}		break;
-			case AL_INVALID_OPERATION:	{ LogManager::getSingleton().logMessage("Invalid Operation when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL); }break;
-			case AL_OUT_OF_MEMORY:		{ LogManager::getSingleton().logMessage("Out of memory when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL); }	break;
+			case AL_INVALID_NAME:		{ Ogre::LogManager::getSingleton().logError("Invalid Name when attempting: OpenAL Minor Version number"); } break;
+			case AL_INVALID_ENUM:		{ Ogre::LogManager::getSingleton().logError("Invalid Enum when attempting: OpenAL Minor Version number"); } break;
+			case AL_INVALID_VALUE:		{ Ogre::LogManager::getSingleton().logError("Invalid Value when attempting: OpenAL Minor Version number"); } break;
+			case AL_INVALID_OPERATION:	{ Ogre::LogManager::getSingleton().logError("Invalid Operation when attempting: OpenAL Minor Version number"); } break;
+			case AL_OUT_OF_MEMORY:		{ Ogre::LogManager::getSingleton().logError("Out of memory when attempting: OpenAL Minor Version number"); }	break;
 			}
-			LogManager::getSingleton().logMessage("Unable to get OpenAL Minor Version number", Ogre::LML_CRITICAL);
+			Ogre::LogManager::getSingleton().logError("Unable to get OpenAL Minor Version number", Ogre::LML_CRITICAL);
 			return false;
 		}
 		alcGetError(NULL);
@@ -248,13 +246,13 @@ namespace OgreOggSound
 		{
 			switch (error)
 			{
-			case AL_INVALID_NAME:		{ LogManager::getSingleton().logMessage("Invalid Name when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL); }		break;
-			case AL_INVALID_ENUM:		{ LogManager::getSingleton().logMessage("Invalid Enum when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL); }		break;
-			case AL_INVALID_VALUE:		{ LogManager::getSingleton().logMessage("Invalid Value when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL);}		break;
-			case AL_INVALID_OPERATION:	{ LogManager::getSingleton().logMessage("Invalid Operation when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL); }break;
-			case AL_OUT_OF_MEMORY:		{ LogManager::getSingleton().logMessage("Out of memory when attempting: OpenAL Minor Version number", Ogre::LML_CRITICAL); }	break;
+			case AL_INVALID_NAME:		{ Ogre::LogManager::getSingleton().logError("Invalid Name when attempting: OpenAL Minor Version number"); } break;
+			case AL_INVALID_ENUM:		{ Ogre::LogManager::getSingleton().logError("Invalid Enum when attempting: OpenAL Minor Version number"); } break;
+			case AL_INVALID_VALUE:		{ Ogre::LogManager::getSingleton().logError("Invalid Value when attempting: OpenAL Minor Version number"); } break;
+			case AL_INVALID_OPERATION:	{ Ogre::LogManager::getSingleton().logError("Invalid Operation when attempting: OpenAL Minor Version number"); } break;
+			case AL_OUT_OF_MEMORY:		{ Ogre::LogManager::getSingleton().logError("Out of memory when attempting: OpenAL Minor Version number"); } break;
 			}
-			LogManager::getSingleton().logMessage("Unable to get OpenAL Major Version number", Ogre::LML_CRITICAL);
+			Ogre::LogManager::getSingleton().logError("Unable to get OpenAL Major Version number");
 			return false;
 		}
 #else
@@ -262,14 +260,14 @@ namespace OgreOggSound
         ALCenum error = alcGetError(device);
         if (error != ALC_NO_ERROR)
 		{
-			LogManager::getSingleton().logMessage("Unable to get OpenAL Minor Version number", Ogre::LML_CRITICAL);
+			Ogre::LogManager::getSingleton().logError("Unable to get OpenAL Minor Version number");
 			return false;
 		}
 		alcGetIntegerv(device, ALC_MAJOR_VERSION, sizeof(majorVersion), &majorVersion);
 		error = alcGetError(device);
         if (error != ALC_NO_ERROR)
 		{
-			LogManager::getSingleton().logMessage("Unable to get OpenAL Major Version number", Ogre::LML_CRITICAL);
+			Ogre::LogManager::getSingleton().logMessage("Unable to get OpenAL Major Version number", Ogre::LML_CRITICAL);
 			return false;
 		}
 		alcCloseDevice(device);
@@ -348,7 +346,7 @@ namespace OgreOggSound
 				mSceneMgr = inst.begin()->second;
 			else
 			{
-				OGRE_EXCEPT(Exception::ERR_INTERNAL_ERROR, "No SceneManager's created - a valid SceneManager is required to create sounds", "OgreOggSoundManager::init()");
+				OGRE_EXCEPT(Ogre::Exception::ERR_INTERNAL_ERROR, "No SceneManager's created - a valid SceneManager is required to create sounds", "OgreOggSoundManager::init()");
 				return false;
 			}
 		}
@@ -384,7 +382,7 @@ namespace OgreOggSound
 			Ogre::LogManager::getSingleton().logMessage("*** --- Recording devices NOT detected!", Ogre::LML_NORMAL);
 		else
 		{
-			LogManager::getSingleton().logMessage("*** --- Recording devices available:", Ogre::LML_NORMAL);
+			Ogre::LogManager::getSingleton().logMessage("*** --- Recording devices available:", Ogre::LML_NORMAL);
 			OgreOggSoundRecord* r=0;
 			if ( r=createRecorder() )
 			{
@@ -403,7 +401,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	const StringVector OgreOggSoundManager::getDeviceList() const
+	const Ogre::StringVector OgreOggSoundManager::getDeviceList() const
 	{
 		const ALCchar* deviceList = mDeviceStrings;
 
@@ -436,13 +434,13 @@ namespace OgreOggSound
 		return (mListener = _createListener()) != 0;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	const StringVector OgreOggSoundManager::getSoundList() const
+	const Ogre::StringVector OgreOggSoundManager::getSoundList() const
 	{
 		#if OGGSOUND_THREADED
 			OGRE_WQ_LOCK_MUTEX(mSoundMutex);
 		#endif
 
-		StringVector list;
+		Ogre::StringVector list;
 		for ( SoundMap::const_iterator iter=mSoundMap.begin(); iter!=mSoundMap.end(); ++iter )
 			list.push_back((*iter).first);
 		return list;
@@ -461,14 +459,14 @@ namespace OgreOggSound
 		return vol;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	OgreOggISound* OgreOggSoundManager::_createSoundImpl(	SceneManager* scnMgr, 
-															const std::string& name, 
+	OgreOggISound* OgreOggSoundManager::_createSoundImpl(	Ogre::SceneManager* scnMgr,
+															const Ogre::String& name,
 															#if OGRE_VERSION_MAJOR == 2
 															Ogre::IdType id,
 															#endif
-															const std::string& file, 
-															bool stream, 
-															bool loop, 
+															const Ogre::String& file,
+															bool stream,
+															bool loop,
 															bool preBuffer,
 															bool immediate)
 	{
@@ -477,7 +475,7 @@ namespace OgreOggSound
 		// MUST be unique
 		if ( hasSound(name) )
 		{
-			Ogre::String msg="*** OgreOggSoundManager::createSound() - Sound with name: "+name+" already exists!";
+			Ogre::String msg="*** OgreOggSoundManager::createSound() - Sound with name: " + name + " already exists!";
 			Ogre::LogManager::getSingleton().logMessage(msg);
 			return 0;
 		}
@@ -610,19 +608,19 @@ namespace OgreOggSound
 		}
 		else
 		{
-			Ogre::String msg="*** OgreOggSoundManager::createSound() - Sound does not have (.ogg | .wav) extension: "+name;
+			Ogre::String msg="*** OgreOggSoundManager::createSound() - Sound does not have (.ogg | .wav) extension: " + name;
 			Ogre::LogManager::getSingleton().logMessage(msg);
 			return 0;
 		}
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	OgreOggISound* OgreOggSoundManager::createSound(const std::string& name, 
-													const std::string& file, 
-													bool stream, 
-													bool loop, 
-													bool preBuffer, 
-													SceneManager* scnMgr,
+	OgreOggISound* OgreOggSoundManager::createSound(const Ogre::String& name,
+													const Ogre::String& file,
+													bool stream,
+													bool loop,
+													bool preBuffer,
+													Ogre::SceneManager* scnMgr,
 													bool immediate)
 	{
 		Ogre::NameValuePairList params;
@@ -642,7 +640,7 @@ namespace OgreOggSound
 				scnMgr = mSceneMgr;
 			else
 			{
-				OGRE_EXCEPT(Exception::ERR_ITEM_NOT_FOUND, "No SceneManager defined!", "OgreOggSoundManager::createSound()");
+				OGRE_EXCEPT(Ogre::Exception::ERR_ITEM_NOT_FOUND, "No SceneManager defined!", "OgreOggSoundManager::createSound()");
 				return 0;
 			}
 		}
@@ -659,9 +657,9 @@ namespace OgreOggSound
 			#endif
 			);
 		}
-		catch (Exception& e)
+		catch (Ogre::Exception& e)
 		{
-			OGRE_EXCEPT(Exception::ERR_INTERNAL_ERROR, e.getFullDescription(), "OgreOggSoundManager::createSound()");
+			OGRE_EXCEPT(Ogre::Exception::ERR_INTERNAL_ERROR, e.getFullDescription(), "OgreOggSoundManager::createSound()");
 		}
 		// create Movable Sound
 		return sound;
@@ -678,7 +676,7 @@ namespace OgreOggSound
 		return l;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	OgreOggISound* OgreOggSoundManager::getSound(const std::string& name)
+	OgreOggISound* OgreOggSoundManager::getSound(const Ogre::String& name)
 	{
 		#if OGGSOUND_THREADED
 			OGRE_WQ_LOCK_MUTEX(mSoundMutex);
@@ -696,7 +694,7 @@ namespace OgreOggSound
 #endif
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::hasSound(const std::string& name)
+	bool OgreOggSoundManager::hasSound(const Ogre::String& name)
 	{
 		#if OGGSOUND_THREADED
 			OGRE_WQ_LOCK_MUTEX(mSoundMutex);
@@ -1230,7 +1228,7 @@ namespace OgreOggSound
 	}
 #	endif
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::setEFXEffectParameter(const std::string& eName, ALint effectType, ALenum attrib, ALfloat param)
+	bool OgreOggSoundManager::setEFXEffectParameter(const Ogre::String& eName, ALint effectType, ALenum attrib, ALfloat param)
 	{
 		if ( !hasEFXSupport() && eName.empty() ) return false;
 
@@ -1252,7 +1250,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::setEFXEffectParameter(const std::string& eName, ALint effectType, ALenum attrib, ALfloat* params)
+	bool OgreOggSoundManager::setEFXEffectParameter(const Ogre::String& eName, ALint effectType, ALenum attrib, ALfloat* params)
 	{
 		if ( !hasEFXSupport() && eName.empty() || !params ) return false;
 
@@ -1274,7 +1272,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::setEFXEffectParameter(const std::string& eName, ALint effectType, ALenum attrib, ALint param)
+	bool OgreOggSoundManager::setEFXEffectParameter(const Ogre::String& eName, ALint effectType, ALenum attrib, ALint param)
 	{
 		if ( !hasEFXSupport() && eName.empty() ) return false;
 
@@ -1296,7 +1294,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::setEFXEffectParameter(const std::string& eName, ALint effectType, ALenum attrib, ALint* params)
+	bool OgreOggSoundManager::setEFXEffectParameter(const Ogre::String& eName, ALint effectType, ALenum attrib, ALint* params)
 	{
 		if ( !hasEFXSupport() && eName.empty() || !params ) return false;
 
@@ -1318,7 +1316,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::attachEffectToSound(const std::string& sName, ALuint slotID, const Ogre::String& effectName, const Ogre::String& filterName)
+	bool OgreOggSoundManager::attachEffectToSound(const Ogre::String& sName, ALuint slotID, const Ogre::String& effectName, const Ogre::String& filterName)
 	{
 		OgreOggISound* sound=0;
 		if ( !(sound = getSound(sName)) ) return false;
@@ -1342,7 +1340,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::attachFilterToSound(const std::string& sName, const Ogre::String& filterName)
+	bool OgreOggSoundManager::attachFilterToSound(const Ogre::String& sName, const Ogre::String& filterName)
 	{
 		OgreOggISound* sound=0;
 		if ( !(sound = getSound(sName)) ) return false;
@@ -1498,7 +1496,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::detachEffectFromSound(const std::string& sName, ALuint slotID)
+	bool OgreOggSoundManager::detachEffectFromSound(const Ogre::String& sName, ALuint slotID)
 	{
 		OgreOggISound* sound=0;
 		if ( !(sound = getSound(sName)) ) return false;
@@ -1525,7 +1523,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::detachFilterFromSound(const std::string& sName)
+	bool OgreOggSoundManager::detachFilterFromSound(const Ogre::String& sName)
 	{
 		OgreOggISound* sound=0;
 		if ( !(sound = getSound(sName)) ) return false;
@@ -1552,7 +1550,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::createEFXFilter(const std::string& fName, ALint filterType, ALfloat gain, ALfloat hfGain, ALfloat lfGain)
+	bool OgreOggSoundManager::createEFXFilter(const Ogre::String& fName, ALint filterType, ALfloat gain, ALfloat hfGain, ALfloat lfGain)
 	{
 		if ( !hasEFXSupport() || fName.empty() || !isEffectSupported(filterType) )
 		{
@@ -1616,9 +1614,9 @@ namespace OgreOggSound
 
 	/*/////////////////////////////////////////////////////////////////*/
 #	if HAVE_EFX == 1
-	bool OgreOggSoundManager::createEFXEffect(const std::string& eName, ALint effectType, EAXREVERBPROPERTIES* props)
+	bool OgreOggSoundManager::createEFXEffect(const Ogre::String& eName, ALint effectType, EAXREVERBPROPERTIES* props)
 #	elif HAVE_EFX == 2
-	bool OgreOggSoundManager::createEFXEffect(const std::string& eName, ALint effectType, EFXEAXREVERBPROPERTIES* props)
+	bool OgreOggSoundManager::createEFXEffect(const Ogre::String& eName, ALint effectType, EFXEAXREVERBPROPERTIES* props)
 #	endif
 	{
 		if ( !hasEFXSupport() || eName.empty() || !isEffectSupported(effectType) )
@@ -1730,7 +1728,7 @@ namespace OgreOggSound
 		}
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::setEFXSoundProperties(const std::string& sName, float airAbsorption, float roomRolloff, float coneOuterHF)
+	bool OgreOggSoundManager::setEFXSoundProperties(const Ogre::String& sName, float airAbsorption, float roomRolloff, float coneOuterHF)
 	{
 		OgreOggISound* sound=0;
 		if ( !(sound = getSound(sName)) ) return false;
@@ -1850,7 +1848,7 @@ namespace OgreOggSound
 		return true;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	ALuint OgreOggSoundManager::_getEFXFilter(const std::string& fName)
+	ALuint OgreOggSoundManager::_getEFXFilter(const Ogre::String& fName)
 	{
 		if ( mFilterList.empty() || !hasEFXSupport() || fName.empty() ) return AL_FILTER_NULL;
 
@@ -1862,7 +1860,7 @@ namespace OgreOggSound
 	}
 
 	/*/////////////////////////////////////////////////////////////////*/
-	ALuint OgreOggSoundManager::_getEFXEffect(const std::string& eName)
+	ALuint OgreOggSoundManager::_getEFXEffect(const Ogre::String& eName)
 	{
 		if ( mEffectList.empty() || !hasEFXSupport() || eName.empty() ) return AL_EFFECT_NULL;
 
@@ -2130,7 +2128,7 @@ namespace OgreOggSound
 		OGRE_WQ_LOCK_MUTEX(mMutex);
 #endif
 		// Destroy all sounds
-		StringVector soundList;
+		Ogre::StringVector soundList;
 
 		#if OGGSOUND_THREADED
 			OGRE_WQ_LOCK_MUTEX(mSoundMutex);
@@ -2141,7 +2139,7 @@ namespace OgreOggSound
 			soundList.push_back(i->first);
 
 		// Destroy individually outside mSoundMap iteration
-		for ( StringVector::iterator i=soundList.begin(); i!=soundList.end(); ++i )
+		for ( Ogre::StringVector::iterator i=soundList.begin(); i!=soundList.end(); ++i )
 		{
 			OgreOggISound* sound=0;
 			if ( sound=getSound((*i)) ) 
@@ -2228,8 +2226,8 @@ namespace OgreOggSound
 		mPausedSounds.clear();
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	void OgreOggSoundManager::_loadSoundImpl(	OgreOggISound* sound, 
-												const String& file, 
+	void OgreOggSoundManager::_loadSoundImpl(	OgreOggISound* sound,
+												const Ogre::String& file,
 												bool prebuffer)
 	{
 		if ( !sound ) return;
@@ -2449,12 +2447,12 @@ namespace OgreOggSound
 		// EAX
 		for(int version = 5; version >= 2; version--)
 		{
-			Ogre::String eaxName="EAX"+Ogre::StringConverter::toString(version)+".0";
+			Ogre::String eaxName="EAX"+Ogre::StringConverter::toString(version) + ".0";
 			if(alIsExtensionPresent(eaxName.c_str()) == AL_TRUE)
 			{
 				mEAXSupport = true;
 				mEAXVersion = version;
-				eaxName="*** --- EAX "+Ogre::StringConverter::toString(version)+".0 Detected";
+				eaxName="*** --- EAX "+Ogre::StringConverter::toString(version) + ".0 Detected";
 				Ogre::LogManager::getSingleton().logMessage(eaxName);
 				break;
 			}
@@ -2557,9 +2555,9 @@ namespace OgreOggSound
 			{
 				switch (error)
 				{
-					case AL_INVALID_VALUE:		{ LogManager::getSingleton().logMessage("Invalid Value when attempting to create more OpenAL sources", Ogre::LML_NORMAL);} 		break;
-					case AL_INVALID_OPERATION:	{ LogManager::getSingleton().logMessage("Invalid Operation when attempting to create more OpenAL sources", Ogre::LML_NORMAL);} 	break;
-					case AL_OUT_OF_MEMORY:		{ LogManager::getSingleton().logMessage("Out of memory when attempting to create more OpenAL sources", Ogre::LML_NORMAL);} 		break;
+					case AL_INVALID_VALUE:		{ Ogre::LogManager::getSingleton().logMessage("Invalid Value when attempting to create more OpenAL sources", Ogre::LML_NORMAL);} 		break;
+					case AL_INVALID_OPERATION:	{ Ogre::LogManager::getSingleton().logMessage("Invalid Operation when attempting to create more OpenAL sources", Ogre::LML_NORMAL);} 	break;
+					case AL_OUT_OF_MEMORY:		{ Ogre::LogManager::getSingleton().logMessage("Out of memory when attempting to create more OpenAL sources", Ogre::LML_NORMAL);} 		break;
 				}
 
 				break;
@@ -2639,7 +2637,7 @@ namespace OgreOggSound
 #endif
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	sharedAudioBuffer* OgreOggSoundManager::_getSharedBuffer(const String& sName)
+	sharedAudioBuffer* OgreOggSoundManager::_getSharedBuffer(const Ogre::String& sName)
 	{
 		if ( sName.empty() ) return AL_NONE;
 
@@ -2676,20 +2674,20 @@ namespace OgreOggSound
 			}
 			else
 			{
-				OGRE_EXCEPT(Exception::ERR_FILE_NOT_FOUND, "Unable to find Ogre::ResourceGroupManager", "OgreOggSoundManager::createSound()");
+				OGRE_EXCEPT(Ogre::Exception::ERR_FILE_NOT_FOUND, "Unable to find Ogre::ResourceGroupManager", "OgreOggSoundManager::createSound()");
 				result.reset();
 			}
 		}
 		catch (Ogre::Exception& e)
 		{
-			OGRE_EXCEPT(Exception::ERR_FILE_NOT_FOUND, e.getFullDescription(), "OgreOggSoundManager::_createSoundImpl()");
+			OGRE_EXCEPT(Ogre::Exception::ERR_FILE_NOT_FOUND, e.getFullDescription(), "OgreOggSoundManager::_createSoundImpl()");
 			result.reset();
 		}
 
 		return result;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::_releaseSharedBuffer(const String& sName, ALuint& buffer)
+	bool OgreOggSoundManager::_releaseSharedBuffer(const Ogre::String& sName, ALuint& buffer)
 	{
 		if ( sName.empty() ) return false;
 
@@ -2718,7 +2716,7 @@ namespace OgreOggSound
 		return false;
 	}	
 	/*/////////////////////////////////////////////////////////////////*/
-	bool OgreOggSoundManager::_registerSharedBuffer(const String& sName, ALuint& buffer, OgreOggISound* parent)
+	bool OgreOggSoundManager::_registerSharedBuffer(const Ogre::String& sName, ALuint& buffer, OgreOggISound* parent)
 	{
 		if ( sName.empty() ) return false;
 

--- a/oggsound/src/OgreOggSoundPlugin.cpp
+++ b/oggsound/src/OgreOggSoundPlugin.cpp
@@ -30,59 +30,59 @@
 
 #include "OgreOggSoundPlugin.h"
 
-using namespace Ogre;
-using namespace OgreOggSound;
-
-const String sPluginName = "OgreOggSound";
-
-//---------------------------------------------------------------------
-OgreOggSoundPlugin::OgreOggSoundPlugin() : 
- mOgreOggSoundFactory(0)
-,mOgreOggSoundManager(0)
+namespace OgreOggSound
 {
+	const Ogre::String sPluginName = "OgreOggSound";
 
-}
-//---------------------------------------------------------------------
-const String& OgreOggSoundPlugin::getName() const
-{
-	return sPluginName;
-}
-//---------------------------------------------------------------------
-void OgreOggSoundPlugin::install()
-{
-	if ( mOgreOggSoundFactory ) return;
+	//---------------------------------------------------------------------
+	OgreOggSoundPlugin::OgreOggSoundPlugin() :
+	 mOgreOggSoundFactory(0)
+	,mOgreOggSoundManager(0)
+	{
 
-	// Create new factory
-	mOgreOggSoundFactory = OGRE_NEW_T(OgreOggSoundFactory, Ogre::MEMCATEGORY_GENERAL)();
+	}
+	//---------------------------------------------------------------------
+	const Ogre::String& OgreOggSoundPlugin::getName() const
+	{
+		return sPluginName;
+	}
+	//---------------------------------------------------------------------
+	void OgreOggSoundPlugin::install()
+	{
+		if ( mOgreOggSoundFactory ) return;
 
-	// Register
-	Root::getSingleton().addMovableObjectFactory(mOgreOggSoundFactory, true);
-}
-//---------------------------------------------------------------------
-void OgreOggSoundPlugin::initialise()
-{
-	if ( mOgreOggSoundManager ) return;
+		// Create new factory
+		mOgreOggSoundFactory = OGRE_NEW_T(OgreOggSoundFactory, Ogre::MEMCATEGORY_GENERAL)();
 
-	//initialise OgreOggSoundManager here
-	mOgreOggSoundManager = OGRE_NEW_T(OgreOggSoundManager, Ogre::MEMCATEGORY_GENERAL)();
-}
-//---------------------------------------------------------------------
-void OgreOggSoundPlugin::shutdown()
-{
-	if ( !mOgreOggSoundManager ) return;
+		// Register
+		Ogre::Root::getSingleton().addMovableObjectFactory(mOgreOggSoundFactory, true);
+	}
+	//---------------------------------------------------------------------
+	void OgreOggSoundPlugin::initialise()
+	{
+		if ( mOgreOggSoundManager ) return;
 
-	// shutdown OgreOggSoundManager here
-	OGRE_DELETE_T(mOgreOggSoundManager, OgreOggSoundManager, Ogre::MEMCATEGORY_GENERAL);
-	mOgreOggSoundManager = 0;
-}
-//---------------------------------------------------------------------
-void OgreOggSoundPlugin::uninstall()
-{
-	if ( !mOgreOggSoundFactory ) return;
+		//initialise OgreOggSoundManager here
+		mOgreOggSoundManager = OGRE_NEW_T(OgreOggSoundManager, Ogre::MEMCATEGORY_GENERAL)();
+	}
+	//---------------------------------------------------------------------
+	void OgreOggSoundPlugin::shutdown()
+	{
+		if ( !mOgreOggSoundManager ) return;
 
-	// unregister
-	Root::getSingleton().removeMovableObjectFactory(mOgreOggSoundFactory);
+		// shutdown OgreOggSoundManager here
+		OGRE_DELETE_T(mOgreOggSoundManager, OgreOggSoundManager, Ogre::MEMCATEGORY_GENERAL);
+		mOgreOggSoundManager = 0;
+	}
+	//---------------------------------------------------------------------
+	void OgreOggSoundPlugin::uninstall()
+	{
+		if ( !mOgreOggSoundFactory ) return;
 
-	OGRE_DELETE_T(mOgreOggSoundFactory, OgreOggSoundFactory, Ogre::MEMCATEGORY_GENERAL);
-	mOgreOggSoundFactory = 0;
+		// unregister
+		Ogre::Root::getSingleton().removeMovableObjectFactory(mOgreOggSoundFactory);
+
+		OGRE_DELETE_T(mOgreOggSoundFactory, OgreOggSoundFactory, Ogre::MEMCATEGORY_GENERAL);
+		mOgreOggSoundFactory = 0;
+	}
 }

--- a/oggsound/src/OgreOggSoundPluginDllStart.cpp
+++ b/oggsound/src/OgreOggSoundPluginDllStart.cpp
@@ -33,27 +33,27 @@
 #include "OgreOggSound.h"
 #include "OgreOggSoundPlugin.h"
 
-using namespace Ogre;
-using namespace OgreOggSound;
-
-OgreOggSoundPlugin* mOgreOggSoundPlugin;
-
-//----------------------------------------------------------------------------------
-// register SecureArchive with Archive Manager
-//----------------------------------------------------------------------------------
-extern "C" void _OGGSOUND_EXPORT dllStartPlugin( void )
+namespace OgreOggSound
 {
-	// Create new plugin
-	mOgreOggSoundPlugin = OGRE_NEW_T(OgreOggSoundPlugin, Ogre::MEMCATEGORY_GENERAL)();
+	OgreOggSoundPlugin* mOgreOggSoundPlugin;
 
-	// Register
-	Root::getSingleton().installPlugin(mOgreOggSoundPlugin);
-}
+	//----------------------------------------------------------------------------------
+	// register SecureArchive with Archive Manager
+	//----------------------------------------------------------------------------------
+	extern "C" void _OGGSOUND_EXPORT dllStartPlugin( void )
+	{
+		// Create new plugin
+		mOgreOggSoundPlugin = OGRE_NEW_T(OgreOggSoundPlugin, Ogre::MEMCATEGORY_GENERAL)();
 
-extern "C" void _OGGSOUND_EXPORT dllStopPlugin( void )
-{
-	Root::getSingleton().uninstallPlugin(mOgreOggSoundPlugin);
+		// Register
+		Ogre::Root::getSingleton().installPlugin(mOgreOggSoundPlugin);
+	}
 
-	OGRE_DELETE_T(mOgreOggSoundPlugin, OgreOggSoundPlugin, Ogre::MEMCATEGORY_GENERAL);
-	mOgreOggSoundPlugin = 0;
+	extern "C" void _OGGSOUND_EXPORT dllStopPlugin( void )
+	{
+		Ogre::Root::getSingleton().uninstallPlugin(mOgreOggSoundPlugin);
+
+		OGRE_DELETE_T(mOgreOggSoundPlugin, OgreOggSoundPlugin, Ogre::MEMCATEGORY_GENERAL);
+		mOgreOggSoundPlugin = 0;
+	}
 }

--- a/oggsound/src/OgreOggSoundRecord.cpp
+++ b/oggsound/src/OgreOggSoundRecord.cpp
@@ -30,219 +30,211 @@
 
 #include "OgreOggSoundRecord.h"
 
-using namespace Ogre;
-
 namespace OgreOggSound
 {
-
-/*/////////////////////////////////////////////////////////////////*/
-		OgreOggSoundRecord::OgreOggSoundRecord(ALCdevice& alDevice) :
-mDevice(&alDevice)
-,mContext(0)
-,mCaptureDevice(0)
-,mDefaultCaptureDevice(0)
-,mSamplesAvailable(0)
-,mDataSize(0)
-,mBuffer(0)
-,mSize(0)
-,mOutputFile("output.wav")
-,mFreq(44100)
-,mBitsPerSample(16)
-,mNumChannels(2)
-,mFormat(AL_FORMAT_STEREO16)
-,mBufferSize(8820)
-,mRecording(false)
-{
-}
-/*/////////////////////////////////////////////////////////////////*/
-void	OgreOggSoundRecord::_updateRecording()
-{
-	if ( !mRecording || !mCaptureDevice || !mFile.is_open() ) return;
-
-	// Find out how many samples have been captured
-	alcGetIntegerv(mCaptureDevice, ALC_CAPTURE_SAMPLES, 1, &mSamplesAvailable);
-
-	// When we have enough data to fill our BUFFERSIZE byte buffer, grab the samples
-	if (mSamplesAvailable > (mBufferSize / mWaveHeader.wfex.nBlockAlign))
+	/*/////////////////////////////////////////////////////////////////*/
+	OgreOggSoundRecord::OgreOggSoundRecord(ALCdevice& alDevice) :
+		mDevice(&alDevice)
+		,mContext(0)
+		,mCaptureDevice(0)
+		,mDefaultCaptureDevice(0)
+		,mSamplesAvailable(0)
+		,mDataSize(0)
+		,mBuffer(0)
+		,mSize(0)
+		,mOutputFile("output.wav")
+		,mFreq(44100)
+		,mBitsPerSample(16)
+		,mNumChannels(2)
+		,mFormat(AL_FORMAT_STEREO16)
+		,mBufferSize(8820)
+		,mRecording(false)
 	{
-		// Consume Samples
-		alcCaptureSamples(mCaptureDevice, mBuffer, mBufferSize / mWaveHeader.wfex.nBlockAlign);
-
-		// Write the audio data to a file
-		mFile.write(mBuffer, mBufferSize);
-
-		// Record total amount of data recorded
-		mDataSize += mBufferSize;
 	}
-}
 
-/*/////////////////////////////////////////////////////////////////*/
-const OgreOggSoundRecord::RecordDeviceList& OgreOggSoundRecord::getCaptureDeviceList() 
-{
-	mDeviceList.clear();
-	// Get list of available Capture Devices
-	const ALchar *pDeviceList = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
-	if (pDeviceList)
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggSoundRecord::_updateRecording()
 	{
-		while (*pDeviceList)
+		if ( !mRecording || !mCaptureDevice || !mFile.is_open() ) return;
+
+		// Find out how many samples have been captured
+		alcGetIntegerv(mCaptureDevice, ALC_CAPTURE_SAMPLES, 1, &mSamplesAvailable);
+
+		// When we have enough data to fill our BUFFERSIZE byte buffer, grab the samples
+		if (mSamplesAvailable > (mBufferSize / mWaveHeader.wfex.nBlockAlign))
 		{
-			mDeviceList.push_back(Ogre::String(pDeviceList));
-			pDeviceList += strlen(pDeviceList) + 1;
+			// Consume Samples
+			alcCaptureSamples(mCaptureDevice, mBuffer, mBufferSize / mWaveHeader.wfex.nBlockAlign);
+
+			// Write the audio data to a file
+			mFile.write(mBuffer, mBufferSize);
+
+			// Record total amount of data recorded
+			mDataSize += mBufferSize;
 		}
 	}
-	return mDeviceList;
-}
 
-
-/*/////////////////////////////////////////////////////////////////*/
-bool	OgreOggSoundRecord::isCaptureAvailable()
-{
-	if (alcIsExtensionPresent(mDevice, "ALC_EXT_CAPTURE") == AL_FALSE)
+	/*/////////////////////////////////////////////////////////////////*/
+	const OgreOggSoundRecord::RecordDeviceList& OgreOggSoundRecord::getCaptureDeviceList()
 	{
-		Ogre::LogManager::getSingleton().logMessage("***--- No Capture Extension detected! ---***");
+		mDeviceList.clear();
+		// Get list of available Capture Devices
+		const ALchar *pDeviceList = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
+		if (pDeviceList)
+		{
+			while (*pDeviceList)
+			{
+				mDeviceList.push_back(Ogre::String(pDeviceList));
+				pDeviceList += strlen(pDeviceList) + 1;
+			}
+		}
+		return mDeviceList;
+	}
+
+	/*/////////////////////////////////////////////////////////////////*/
+	bool OgreOggSoundRecord::isCaptureAvailable()
+	{
+		if (alcIsExtensionPresent(mDevice, "ALC_EXT_CAPTURE") == AL_FALSE)
+		{
+			Ogre::LogManager::getSingleton().logMessage("*** --- No Capture Extension detected! --- ***");
+			return false;
+		}
+		return true;
+	}
+
+	/*/////////////////////////////////////////////////////////////////*/
+	bool OgreOggSoundRecord::initCaptureDevice(const Ogre::String& deviceName, const Ogre::String& fileName, ALCuint freq, ALCenum format, ALsizei bufferSize)
+	{
+		if ( !isCaptureAvailable() ) return false;
+
+		mFreq=freq;
+		mFormat=format;
+		mBufferSize=bufferSize;
+
+		// Set channel
+		if		( mFormat==AL_FORMAT_MONO8 )	{ mNumChannels=1; mBitsPerSample=8; }
+		else if ( mFormat==AL_FORMAT_STEREO8 )	{ mNumChannels=2; mBitsPerSample=8; }
+		else if ( mFormat==AL_FORMAT_MONO16 )	{ mNumChannels=1; mBitsPerSample=16;}
+		else if ( mFormat==AL_FORMAT_STEREO16 )	{ mNumChannels=2; mBitsPerSample=16;}
+
+		// Selected device
+		mDeviceName = deviceName;
+
+		// No device specified - select default
+		if ( mDeviceName.empty() )
+		{
+			// Get the name of the 'default' capture device
+			mDefaultCaptureDevice = alcGetString(NULL, ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER);
+			mDeviceName = mDefaultCaptureDevice;
+			Ogre::LogManager::getSingleton().logMessage("Selected Default Capture Device: " + mDeviceName);
+		}
+
+		mCaptureDevice = alcCaptureOpenDevice(mDeviceName.c_str(), mFreq, mFormat, mBufferSize);
+		if ( mCaptureDevice )
+		{
+			Ogre::LogManager::getSingleton().logMessage("Opened Capture Device: " + mDeviceName);
+
+			// attempt to open file (binary | writing)
+			mFile.open(mOutputFile.c_str(), std::ios::out|std::ios::binary);
+
+			if ( mFile.is_open() )
+			{
+				// Prepare a WAVE file header for the captured data
+				sprintf(mWaveHeader.szRIFF, "RIFF");
+				mWaveHeader.lRIFFSize = 0;
+				sprintf(mWaveHeader.szWave, "WAVE");
+				sprintf(mWaveHeader.szFmt, "fmt ");
+				mWaveHeader.lFmtSize = sizeof(wFormat);
+				mWaveHeader.wfex.nChannels = mNumChannels;
+				mWaveHeader.wfex.wBitsPerSample = mBitsPerSample;
+				mWaveHeader.wfex.wFormatTag = 0x0001;
+				mWaveHeader.wfex.nSamplesPerSec = mFreq;
+				mWaveHeader.wfex.nBlockAlign = mWaveHeader.wfex.nChannels * mWaveHeader.wfex.wBitsPerSample / 8;
+				mWaveHeader.wfex.nAvgBytesPerSec = mWaveHeader.wfex.nSamplesPerSec * mWaveHeader.wfex.nBlockAlign;
+				mWaveHeader.wfex.cbSize = 0;
+				sprintf(mWaveHeader.szData, "data");
+				mWaveHeader.lDataSize = 0;
+
+				mFile.write(reinterpret_cast<char*>(&mWaveHeader), sizeof(WAVEHEADER));
+
+				// Generate buffer for capture data
+				mBuffer = OGRE_ALLOC_T(ALchar, mBufferSize, Ogre::MEMCATEGORY_GENERAL);
+
+				return true;
+			}
+
+			Ogre::LogManager::getSingleton().logError("*** --- Unable to open recording file: " + mOutputFile);
+			return false;
+		}
+
 		return false;
 	}
-	return true;
-}
 
-/*/////////////////////////////////////////////////////////////////*/
-bool	OgreOggSoundRecord::initCaptureDevice(const Ogre::String& deviceName, const Ogre::String& fileName, ALCuint freq, ALCenum format, ALsizei bufferSize)
-{
-	if ( !isCaptureAvailable() ) return false;
-
-	mFreq=freq;
-	mFormat=format;
-	mBufferSize=bufferSize;
-
-	// Set channel
-	if		( mFormat==AL_FORMAT_MONO8 )	{ mNumChannels=1; mBitsPerSample=8; }
-	else if ( mFormat==AL_FORMAT_STEREO8 )	{ mNumChannels=2; mBitsPerSample=8; }
-	else if ( mFormat==AL_FORMAT_MONO16 )	{ mNumChannels=1; mBitsPerSample=16;}
-	else if ( mFormat==AL_FORMAT_STEREO16 )	{ mNumChannels=2; mBitsPerSample=16;}
-
-	// Selected device
-	mDeviceName = deviceName;
-
-	// No device specified - select default
-	if ( mDeviceName.empty() )
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggSoundRecord::startRecording()
 	{
-		// Get the name of the 'default' capture device
-		mDefaultCaptureDevice = alcGetString(NULL, ALC_CAPTURE_DEFAULT_DEVICE_SPECIFIER);
-		mDeviceName = mDefaultCaptureDevice;
-		LogManager::getSingleton().logMessage("Selected Default Capture Device: "+mDeviceName);
+		if ( !mCaptureDevice ) return;
+
+		// Start audio capture
+		alcCaptureStart(mCaptureDevice);
+
+		// Flag recording
+		mRecording = true;
 	}
 
-	mCaptureDevice = alcCaptureOpenDevice(mDeviceName.c_str(), mFreq, mFormat, mBufferSize);
-	if ( mCaptureDevice )
+	/*/////////////////////////////////////////////////////////////////*/
+	void OgreOggSoundRecord::stopRecording()
 	{
-		using namespace std;
+		if ( !mRecording || !mCaptureDevice ) return;
 
-		LogManager::getSingleton().logMessage("Opened Capture Device: "+mDeviceName);
+		// Stop capture
+		alcCaptureStop(mCaptureDevice);
 
-		// attempt to open file (binary | writing)
-		mFile.open(mOutputFile.c_str(), ios::out|ios::binary);
+		mRecording = false;
+	}
 
+	/*/////////////////////////////////////////////////////////////////*/
+	OgreOggSoundRecord::~OgreOggSoundRecord()
+	{
+		// Stop recording if necessary
+		if ( mRecording ) stopRecording();
+
+		// Close file write output
 		if ( mFile.is_open() )
 		{
-			// Prepare a WAVE file header for the captured data
-			sprintf(mWaveHeader.szRIFF, "RIFF");
-			mWaveHeader.lRIFFSize = 0;
-			sprintf(mWaveHeader.szWave, "WAVE");
-			sprintf(mWaveHeader.szFmt, "fmt ");
-			mWaveHeader.lFmtSize = sizeof(wFormat);		
-			mWaveHeader.wfex.nChannels = mNumChannels;
-			mWaveHeader.wfex.wBitsPerSample = mBitsPerSample;
-			mWaveHeader.wfex.wFormatTag = 0x0001;
-			mWaveHeader.wfex.nSamplesPerSec = mFreq;
-			mWaveHeader.wfex.nBlockAlign = mWaveHeader.wfex.nChannels * mWaveHeader.wfex.wBitsPerSample / 8;
-			mWaveHeader.wfex.nAvgBytesPerSec = mWaveHeader.wfex.nSamplesPerSec * mWaveHeader.wfex.nBlockAlign;
-			mWaveHeader.wfex.cbSize = 0;
-			sprintf(mWaveHeader.szData, "data");
-			mWaveHeader.lDataSize = 0;
+			// Check if any Samples haven't been consumed yet
+			alcGetIntegerv(mCaptureDevice, ALC_CAPTURE_SAMPLES, 1, &mSamplesAvailable);
+			while (mSamplesAvailable)
+			{
+				if (mSamplesAvailable > (mBufferSize / mWaveHeader.wfex.nBlockAlign))
+				{
+					alcCaptureSamples(mCaptureDevice, mBuffer, mBufferSize / mWaveHeader.wfex.nBlockAlign);
+					mFile.write(mBuffer, mBufferSize);
+					mSamplesAvailable -= (mBufferSize / mWaveHeader.wfex.nBlockAlign);
+					mDataSize += mBufferSize;
+				}
+				else
+				{
+					alcCaptureSamples(mCaptureDevice, mBuffer, mSamplesAvailable);
+					mFile.write(mBuffer, mSamplesAvailable * mWaveHeader.wfex.nBlockAlign);
+					mDataSize += mSamplesAvailable * mWaveHeader.wfex.nBlockAlign;
+					mSamplesAvailable = 0;
+				}
+			}
 
-			mFile.write(reinterpret_cast<char*>(&mWaveHeader), sizeof(WAVEHEADER));
-
-			// Generate buffer for capture data
-			mBuffer = OGRE_ALLOC_T(ALchar, mBufferSize, Ogre::MEMCATEGORY_GENERAL);
-
-			return true;
+			// Fill in Size information in Wave Header
+			mFile.seekp(4);
+			mSize = mDataSize + sizeof(WAVEHEADER) - 8;
+			mFile.write(reinterpret_cast<char*>(&mSize), 4);
+			mFile.seekp(42);
+			mFile.write(reinterpret_cast<char*>(&mDataSize), 4);
+			mFile.close();
 		}
 
-		LogManager::getSingleton().logMessage("***--- Unable to open recording file: "+mOutputFile);
-		return false;
+		// Destroy audio buffer
+		if ( mBuffer ) 	OGRE_FREE(mBuffer, Ogre::MEMCATEGORY_GENERAL);
+
+		// Close the Capture Device
+		if ( mCaptureDevice ) alcCaptureCloseDevice(mCaptureDevice);
 	}
-
-	return false;
-}
-
-/*/////////////////////////////////////////////////////////////////*/
-void	OgreOggSoundRecord::startRecording()
-{
-	if ( !mCaptureDevice ) return;
-
-	// Start audio capture
-	alcCaptureStart(mCaptureDevice);
-
-	// Flag recording
-	mRecording = true;
-}
-
-/*/////////////////////////////////////////////////////////////////*/
-void	OgreOggSoundRecord::stopRecording()
-{
-	if ( !mRecording || !mCaptureDevice ) return;
-
-	// Stop capture
-	alcCaptureStop(mCaptureDevice);
-
-	mRecording = false;
-
-}
-
-/*/////////////////////////////////////////////////////////////////*/
-		OgreOggSoundRecord::~OgreOggSoundRecord()
-{
-	// Stop recording if necessary
-	if ( mRecording ) stopRecording();
-
-	// Close file write output
-	if ( mFile.is_open() ) 
-	{
-		// Check if any Samples haven't been consumed yet
-		alcGetIntegerv(mCaptureDevice, ALC_CAPTURE_SAMPLES, 1, &mSamplesAvailable);
-		while (mSamplesAvailable)
-		{
-			if (mSamplesAvailable > (mBufferSize / mWaveHeader.wfex.nBlockAlign))
-			{
-				alcCaptureSamples(mCaptureDevice, mBuffer, mBufferSize / mWaveHeader.wfex.nBlockAlign);
-				mFile.write(mBuffer, mBufferSize);
-				mSamplesAvailable -= (mBufferSize / mWaveHeader.wfex.nBlockAlign);
-				mDataSize += mBufferSize;
-			}
-			else
-			{
-				alcCaptureSamples(mCaptureDevice, mBuffer, mSamplesAvailable);
-				mFile.write(mBuffer, mSamplesAvailable * mWaveHeader.wfex.nBlockAlign);
-				mDataSize += mSamplesAvailable * mWaveHeader.wfex.nBlockAlign;
-				mSamplesAvailable = 0;
-			}
-		}
-
-		// Fill in Size information in Wave Header
-		mFile.seekp(4);
-		mSize = mDataSize + sizeof(WAVEHEADER) - 8;
-		mFile.write(reinterpret_cast<char*>(&mSize), 4);
-		mFile.seekp(42);
-		mFile.write(reinterpret_cast<char*>(&mDataSize), 4);
-		mFile.close();
-	}						  
-
-	// Destroy audio buffer
-	if ( mBuffer ) 	OGRE_FREE(mBuffer, Ogre::MEMCATEGORY_GENERAL);
-
-	// Close the Capture Device
-	if ( mCaptureDevice ) alcCaptureCloseDevice(mCaptureDevice);
-}
-
-
 }

--- a/oggsound/src/OgreOggStaticSound.cpp
+++ b/oggsound/src/OgreOggStaticSound.cpp
@@ -35,7 +35,6 @@
 
 namespace OgreOggSound
 {
-
 	/*/////////////////////////////////////////////////////////////////*/
 	OgreOggStaticSound::OgreOggStaticSound(
 		const Ogre::String& name, Ogre::SceneManager* scnMgr
@@ -244,7 +243,7 @@ namespace OgreOggSound
 			break;
 		default:
 			// Couldn't determine buffer format so log the error and default to mono
-			Ogre::LogManager::getSingleton().logMessage("!!WARNING!! Could not determine buffer format!  Defaulting to MONO");
+			Ogre::LogManager::getSingleton().logMessage("!!WARNING!! Could not determine buffer format! Defaulting to MONO");
 
 			mFormat = AL_FORMAT_MONO16;
 			// Set BufferSize to 250ms (Frequency * 2 (16bit) divided by 4 (quarter of a second))

--- a/oggsound/src/OgreOggStreamSound.cpp
+++ b/oggsound/src/OgreOggStreamSound.cpp
@@ -108,7 +108,7 @@ namespace OgreOggSound
 		{
 			if ( mLoopOffset>=mPlayTime )
 			{
-				Ogre::LogManager::getSingleton().logMessage("**** OgreOggStreamSound::open() ERROR - loop time invalid! ****", Ogre::LML_CRITICAL);
+				Ogre::LogManager::getSingleton().logError("*** OgreOggStreamSound::open() - Loop time invalid!");
 				mLoopOffset=0.f;
 			}
 		}
@@ -140,7 +140,7 @@ namespace OgreOggSound
 		if ( !mAudioStream )
 			if ( mLoopOffset>=mPlayTime ) 
 			{
-				Ogre::LogManager::getSingleton().logMessage("**** OgreOggStreamSound::setLoopOffset() ERROR - loop time invalid! ****", Ogre::LML_CRITICAL);
+				Ogre::LogManager::getSingleton().logError("*** OgreOggStreamSound::setLoopOffset() - Loop time invalid!");
 				// Invalid - cancel loop point
 				mLoopOffset=0.f;
 			}
@@ -223,7 +223,7 @@ namespace OgreOggSound
 			break;
 		default:
 			// Couldn't determine buffer format so log the error and default to mono
-			Ogre::LogManager::getSingleton().logMessage("!!WARNING!! Could not determine buffer format!  Defaulting to MONO");
+			Ogre::LogManager::getSingleton().logMessage("!!WARNING!! Could not determine buffer format! Defaulting to MONO");
 
 			mFormat = AL_FORMAT_MONO16;
 			// Set BufferSize to 250ms (Frequency * 2 (16bit) divided by 4 (quarter of a second))
@@ -375,7 +375,7 @@ namespace OgreOggSound
 				{
 					if ( ov_time_seek(&mOggStream, 0 + mLoopOffset)!= 0 )
 					{
-						Ogre::LogManager::getSingleton().logMessage("***--- OgreOggStream::_stream() - ERROR looping stream, ogg file NOT seekable!");
+						Ogre::LogManager::getSingleton().logError("*** OgreOggStream::_stream() - Looping stream, ogg file NOT seekable!");
 						break;
 					}
 				}
@@ -443,7 +443,8 @@ namespace OgreOggSound
 			alSourceUnqueueBuffers(mSource, 1, &buffer);
 
 			// Any problems?
-			if ( alGetError()!=AL_NO_ERROR ) Ogre::LogManager::getSingleton().logMessage("*** Unable to unqueue buffers");
+			if ( alGetError()!=AL_NO_ERROR )
+				Ogre::LogManager::getSingleton().logError("*** OgreOggStreamSound::_dequeue() - Unable to unqueue buffers");
 		}
 	}		 
 	/*/////////////////////////////////////////////////////////////////*/
@@ -539,7 +540,7 @@ namespace OgreOggSound
 		alSourcePlay(mSource);
 		if ( alGetError() )
 		{
-			Ogre::LogManager::getSingleton().logMessage("Unable to play sound");
+			Ogre::LogManager::getSingleton().logError("*** OgreOggStreamSound::_playImpl() - Unable to play sound");
 			return;
 		}
 		// Set play flag

--- a/oggsound/src/OgreOggStreamWavSound.cpp
+++ b/oggsound/src/OgreOggStreamWavSound.cpp
@@ -198,7 +198,7 @@ namespace OgreOggSound
 			}
 			else			
 			{
-				Ogre::LogManager::getSingleton().logMessage("**** OgreOggStreamWavSound::open() ERROR - loop time invalid! ****", Ogre::LML_NORMAL);
+				Ogre::LogManager::getSingleton().logError("*** OgreOggStreamWavSound::open() - Loop time invalid!", Ogre::LML_NORMAL);
 				mLoopOffset=0.f;
 			}
 		}
@@ -485,7 +485,7 @@ namespace OgreOggSound
 			// Check valid loop point
 			if ( mLoopOffset>=mPlayTime ) 
 			{
-				Ogre::LogManager::getSingleton().logMessage("**** OgreOggStreamWavSound::setLoopOffset() ERROR - loop time invalid! ****", Ogre::LML_CRITICAL);
+				Ogre::LogManager::getSingleton().logError("*** OgreOggStreamWavSound::setLoopOffset() - Loop time invalid!", Ogre::LML_CRITICAL);
 				return;
 			}
 
@@ -626,7 +626,7 @@ namespace OgreOggSound
 			// Any problems?
 			if ( alGetError() ) 
 			{
-				Ogre::LogManager::getSingleton().logMessage("*** Unable to unqueue buffers");
+				Ogre::LogManager::getSingleton().logError("*** OgreOggStreamWavSound::_dequeue() - Unable to unqueue buffers");
 			}
 		}
 	}
@@ -660,7 +660,7 @@ namespace OgreOggSound
 		alSourcePlay(mSource);
 		if ( alGetError() )
 		{
-			Ogre::LogManager::getSingleton().logMessage("Unable to play sound");
+			Ogre::LogManager::getSingleton().logError("*** OgreOggStreamWavSound::_playImpl() - Unable to play sound");
 			return;
 		}
 


### PR DESCRIPTION
Also:
 - Removed instances of `using namespace Ogre`, `using namespace OgreOggSound` and `using namespace std`
 - Replaced `std::string` with `Ogre::String` (for consistency, some places used it and others didn't)
