### PR TITLE
fix build with Ogre2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 2.8)
 project(OgreVideoAudio)
 
-find_package(OGRE REQUIRED OPTIONAL_COMPONENTS Bites CONFIG)
+find_package(OGRE REQUIRED OPTIONAL_COMPONENTS Bites)
 
 option(BUILD_DEMOS "Build demo (requires Ogre Bites and both Audio and Video)" ON)
 option(BUILD_VIDEOPLUGIN "Build the Theora Video plugin" ON)

--- a/demos/player/player.cpp
+++ b/demos/player/player.cpp
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
 #if OGRE_PLATFORM == OGRE_PLATFORM_WIN32
 		MessageBox( NULL, e.getFullDescription().c_str(), "An exception has occured!", MB_OK | MB_ICONERROR | MB_TASKMODAL);
 #else
-		Ogre::LogManager::getSingleton().logError(e.getFullDescription());
+		OGRE_LOG_ERROR(e.getFullDescription());
 #endif
 	}
 

--- a/oggsound/include/OgreOggISound.h
+++ b/oggsound/include/OgreOggISound.h
@@ -527,7 +527,7 @@ namespace OgreOggSound
 		OgreOggISound(
 			const Ogre::String& name
 			#if OGRE_VERSION_MAJOR == 2
-			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 			#endif
 		);
 		/** Superclass destructor.

--- a/oggsound/include/OgreOggListener.h
+++ b/oggsound/include/OgreOggListener.h
@@ -107,9 +107,11 @@ namespace OgreOggSound
 			bounding radius for this object.
 		 */
 		virtual float getBoundingRadius(void) const;
-		void _updateRenderQueue(Ogre::RenderQueue *queue) override {}
 		#if OGRE_VERSION_MAJOR != 2
+		void _updateRenderQueue(Ogre::RenderQueue *queue) override {}
 		void visitRenderables(Ogre::Renderable::Visitor* visitor, bool debugRenderables) override {}
+		#else
+		void _updateRenderQueue(Ogre::RenderQueue *queue) {}
 		#endif
 		/** Attach callback
 		@remarks

--- a/oggsound/include/OgreOggSound.h
+++ b/oggsound/include/OgreOggSound.h
@@ -41,3 +41,11 @@
 #include "OgreOggSoundRecord.h"
 #include "OgreOggSoundFactory.h"
 #include "OgreOggSoundManager.h"
+
+#ifndef OGRE_LOG_ERROR
+#if OGRE_VERSION_MAJOR == 2
+#define OGRE_LOG_ERROR(a) Ogre::LogManager::getSingleton().logMessage(Ogre::LML_CRITICAL, a)
+#else
+#define OGRE_LOG_ERROR(a) Ogre::LogManager::getSingleton().logError(a)
+#endif
+#endif

--- a/oggsound/include/OgreOggSoundFactory.h
+++ b/oggsound/include/OgreOggSoundFactory.h
@@ -54,6 +54,10 @@ namespace OgreOggSound
 		static Ogre::String FACTORY_TYPE_NAME;
 
 		const Ogre::String& getType(void) const;
+		
+		#if OGRE_VERSION_MAJOR == 2
+		void destroyInstance( Ogre::MovableObject* obj);
+		#endif
 	};
 }
 

--- a/oggsound/include/OgreOggStaticSound.h
+++ b/oggsound/include/OgreOggStaticSound.h
@@ -92,7 +92,7 @@ namespace OgreOggSound
 		OgreOggStaticSound(
 			const Ogre::String& name
 			#if OGRE_VERSION_MAJOR == 2
-			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 			#endif
 		);
 		/**

--- a/oggsound/include/OgreOggStaticWavSound.h
+++ b/oggsound/include/OgreOggStaticWavSound.h
@@ -129,7 +129,7 @@ namespace OgreOggSound
 		OgreOggStaticWavSound(
 			const Ogre::String& name
 			#if OGRE_VERSION_MAJOR == 2
-			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 			#endif
 		);
 		/**

--- a/oggsound/include/OgreOggStreamBufferSound.h
+++ b/oggsound/include/OgreOggStreamBufferSound.h
@@ -96,7 +96,7 @@ namespace OgreOggSound
 		OgreOggStreamBufferSound(
 			const Ogre::String& name
 			#if OGRE_VERSION_MAJOR == 2
-			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 			#endif
 		);
 		/**

--- a/oggsound/include/OgreOggStreamSound.h
+++ b/oggsound/include/OgreOggStreamSound.h
@@ -109,7 +109,7 @@ namespace OgreOggSound
 		OgreOggStreamSound(
 			const Ogre::String& name
 			#if OGRE_VERSION_MAJOR == 2
-			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 			#endif
 		);
 		/**

--- a/oggsound/include/OgreOggStreamWavSound.h
+++ b/oggsound/include/OgreOggStreamWavSound.h
@@ -109,7 +109,7 @@ namespace OgreOggSound
 		OgreOggStreamWavSound(
 			const Ogre::String& name
 			#if OGRE_VERSION_MAJOR == 2
-			, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+			, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 			#endif
 		);
 		/**

--- a/oggsound/src/OgreOggISound.cpp
+++ b/oggsound/src/OgreOggISound.cpp
@@ -75,7 +75,7 @@ namespace OgreOggSound
 	OgreOggISound::OgreOggISound(
 		const Ogre::String& name
 		#if OGRE_VERSION_MAJOR == 2
-		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 		#endif
 	) : 
 	#if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR > 0
@@ -83,9 +83,9 @@ namespace OgreOggSound
 	mPosition(0,0,0),
 	mDirection(0,0,0),
 	#else
-	MovableObject(name)
+	MovableObject(name),
 	#endif
-	,mSource(0) 
+	mSource(0) 
 	,mLoop(false) 
 	,mState(SS_NONE) 
 	,mReferenceDistance(1.0f) 
@@ -548,7 +548,7 @@ namespace OgreOggSound
 		alSourcef(mSource, AL_SEC_OFFSET, mPlayPos);
 		if (alGetError())
 		{
-			Ogre::LogManager::getSingleton().logError("OgreOggISound::_recoverPlayPosition() - Unable to set play position");
+			OGRE_LOG_ERROR("OgreOggISound::_recoverPlayPosition() - Unable to set play position");
 		}
 	}
 	/*/////////////////////////////////////////////////////////////////*/
@@ -576,7 +576,7 @@ namespace OgreOggSound
 		alSourcef(mSource, AL_SEC_OFFSET, seconds);
 		if (alGetError())
 		{
-			Ogre::LogManager::getSingleton().logError("OgreOggISound::setPlayPosition() - Error setting play position");
+			OGRE_LOG_ERROR("OgreOggISound::setPlayPosition() - Error setting play position");
 		}
 	}
 	/*/////////////////////////////////////////////////////////////////*/
@@ -592,7 +592,7 @@ namespace OgreOggSound
 		alGetSourcef(mSource, AL_SEC_OFFSET, &offset);
 		if (alGetError())
 		{
-			Ogre::LogManager::getSingleton().logError("OgreOggISound::setPlayPosition() - Error getting play position");
+			OGRE_LOG_ERROR("OgreOggISound::setPlayPosition() - Error getting play position");
 			return -1.f;
 		}
 			
@@ -723,8 +723,11 @@ namespace OgreOggSound
 			#endif
 		);
 
+		#if OGRE_VERSION_MAJOR != 2
 		// Immediately set position/orientation when attached
 		mLocalTransformDirty = true;
+		#endif
+		
 		update(0);
 
 		return;

--- a/oggsound/src/OgreOggListener.cpp
+++ b/oggsound/src/OgreOggListener.cpp
@@ -127,7 +127,9 @@ namespace OgreOggSound
 		// Immediately set position/orientation when attached
 		if (mParentNode)
 		{
+			#if OGRE_VERSION_MAJOR != 2
 			mLocalTransformDirty = true;
+			#endif
 			update();
 		}
 

--- a/oggsound/src/OgreOggSoundFactory.cpp
+++ b/oggsound/src/OgreOggSoundFactory.cpp
@@ -44,14 +44,14 @@ namespace OgreOggSound
 	}
 	//-----------------------------------------------------------------------
 	#if OGRE_VERSION_MAJOR == 2 && OGRE_VERSION_MINOR > 0
-	Ogre::MovableObject* OgreOggSoundFactory::createInstanceImpl(IdType id, Ogre::ObjectMemoryManager *objectMemoryManager, Ogre::SceneManager* manager, const Ogre::NameValuePairList* params)
+	Ogre::MovableObject* OgreOggSoundFactory::createInstanceImpl(Ogre::IdType id, Ogre::ObjectMemoryManager *objectMemoryManager, Ogre::SceneManager* manager, const Ogre::NameValuePairList* params)
 	#else
 	Ogre::MovableObject* OgreOggSoundFactory::createInstanceImpl(const Ogre::String& name, const Ogre::NameValuePairList* params)
 	#endif
 	{
 		Ogre::String fileName;
 		#if OGRE_VERSION_MAJOR == 2
-		Ogre::String reName = BLANKSTRING;
+		Ogre::String reName = Ogre::BLANKSTRING;
 		#else
 		Ogre::String reName = name;
 		#endif
@@ -122,4 +122,16 @@ namespace OgreOggSound
 
 		return 0;
 	}
+
+#if OGRE_VERSION_MAJOR == 2
+	void OgreOggSoundFactory::destroyInstance( Ogre::MovableObject* obj)
+	{
+		if ( dynamic_cast<OgreOggListener*>(obj) )
+			// destroy the listener
+			OgreOggSoundManager::getSingletonPtr()->_destroyListener();
+		else
+			// destroy the sound
+			OgreOggSoundManager::getSingletonPtr()->_releaseSoundImpl(static_cast<OgreOggISound*>(obj));
+	}
+#endif
 }

--- a/oggsound/src/OgreOggSoundRecord.cpp
+++ b/oggsound/src/OgreOggSoundRecord.cpp
@@ -29,6 +29,7 @@
 */
 
 #include "OgreOggSoundRecord.h"
+#include "OgreOggSound.h"
 
 namespace OgreOggSound
 {
@@ -153,11 +154,11 @@ namespace OgreOggSound
 				return true;
 			}
 
-			Ogre::LogManager::getSingleton().logError("OgreOggSoundRecord::initCaptureDevice() - Unable to open recording file: " + mOutputFile);
+			OGRE_LOG_ERROR("OgreOggSoundRecord::initCaptureDevice() - Unable to open recording file: " + mOutputFile);
 			return false;
 		}
 
-		Ogre::LogManager::getSingleton().logError("OgreOggSoundRecord::initCaptureDevice() - Unable to open recording device: " + mDeviceName);
+		OGRE_LOG_ERROR("OgreOggSoundRecord::initCaptureDevice() - Unable to open recording device: " + mDeviceName);
 
 		return false;
 	}

--- a/oggsound/src/OgreOggStaticSound.cpp
+++ b/oggsound/src/OgreOggStaticSound.cpp
@@ -39,12 +39,12 @@ namespace OgreOggSound
 	OgreOggStaticSound::OgreOggStaticSound(
 		const Ogre::String& name
 		#if OGRE_VERSION_MAJOR == 2
-		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 		#endif
 	) : OgreOggISound(
 		name
 		#if OGRE_VERSION_MAJOR == 2
-		, id, objMemMgr, renderQueueId
+		, scnMgr, id, objMemMgr, renderQueueId
 		#endif
 	)
 	,mVorbisInfo(0)
@@ -364,7 +364,7 @@ namespace OgreOggSound
 			alSourcei(mSource, AL_LOOPING, loop);
 
 			if ( alGetError() != AL_NO_ERROR )
-				Ogre::LogManager::getSingleton().logError("OgreOggStaticSound::loop() - Unable to set looping status!");
+				OGRE_LOG_ERROR("OgreOggStaticSound::loop() - Unable to set looping status!");
 		}
 		else
 			Ogre::LogManager::getSingleton().logMessage("OgreOggStaticSound::loop() - No source attached to sound!");

--- a/oggsound/src/OgreOggStaticWavSound.cpp
+++ b/oggsound/src/OgreOggStaticWavSound.cpp
@@ -40,12 +40,12 @@ namespace OgreOggSound
 	OgreOggStaticWavSound::OgreOggStaticWavSound(
 		const Ogre::String& name
 		#if OGRE_VERSION_MAJOR == 2
-		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 		#endif
 	) : OgreOggISound(
 			name
 			#if OGRE_VERSION_MAJOR == 2
-			, id, objMemMgr, renderQueueId
+			, scnMgr, id, objMemMgr, renderQueueId
 			#endif
 		)
 		,mAudioName("")
@@ -502,7 +502,7 @@ namespace OgreOggSound
 			alSourcei(mSource, AL_LOOPING, loop);
 
 			if ( alGetError() != AL_NO_ERROR )
-				Ogre::LogManager::getSingleton().logError("OgreOggStaticWavSound::loop() - Unable to set looping status!");
+				OGRE_LOG_ERROR("OgreOggStaticWavSound::loop() - Unable to set looping status!");
 		}
 		else
 			Ogre::LogManager::getSingleton().logMessage("OgreOggStaticWavSound::loop() - No source attached to sound!");

--- a/oggsound/src/OgreOggStreamBufferSound.cpp
+++ b/oggsound/src/OgreOggStreamBufferSound.cpp
@@ -40,12 +40,12 @@ namespace OgreOggSound
 	OgreOggStreamBufferSound::OgreOggStreamBufferSound(
 		const Ogre::String& name
 		#if OGRE_VERSION_MAJOR == 2
-		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 		#endif
 	) : OgreOggISound(
 		name
 		#if OGRE_VERSION_MAJOR == 2
-		, id, objMemMgr, renderQueueId
+		, scnMgr, id, objMemMgr, renderQueueId
 		#endif
 	)
 		,mFreq(0)

--- a/oggsound/src/OgreOggStreamSound.cpp
+++ b/oggsound/src/OgreOggStreamSound.cpp
@@ -39,12 +39,12 @@ namespace OgreOggSound
 	OgreOggStreamSound::OgreOggStreamSound(
 		const Ogre::String& name
 		#if OGRE_VERSION_MAJOR == 2
-		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 		#endif
 	) : OgreOggISound(
 		name
 		#if OGRE_VERSION_MAJOR == 2
-		, id, objMemMgr, renderQueueId
+		, scnMgr, id, objMemMgr, renderQueueId
 		#endif
 	)
 	,mVorbisInfo(0)
@@ -114,7 +114,7 @@ namespace OgreOggSound
 		{
 			if ( mLoopOffset>=mPlayTime )
 			{
-				Ogre::LogManager::getSingleton().logError("OgreOggStreamSound::open() - Loop time invalid!");
+				OGRE_LOG_ERROR("OgreOggStreamSound::open() - Loop time invalid!");
 				mLoopOffset=0.f;
 			}
 		}
@@ -145,7 +145,7 @@ namespace OgreOggSound
 		if ( !mAudioStream )
 			if ( mLoopOffset>=mPlayTime ) 
 			{
-				Ogre::LogManager::getSingleton().logError("OgreOggStreamSound::setLoopOffset() - Loop time invalid!");
+				OGRE_LOG_ERROR("OgreOggStreamSound::setLoopOffset() - Loop time invalid!");
 				// Invalid - cancel loop point
 				mLoopOffset=0.f;
 			}
@@ -380,7 +380,7 @@ namespace OgreOggSound
 				{
 					if ( ov_time_seek(&mOggStream, 0 + mLoopOffset)!= 0 )
 					{
-						Ogre::LogManager::getSingleton().logError("OgreOggStream::_stream() - Looping stream, ogg file NOT seekable!");
+						OGRE_LOG_ERROR("OgreOggStream::_stream() - Looping stream, ogg file NOT seekable!");
 						break;
 					}
 				}
@@ -449,7 +449,7 @@ namespace OgreOggSound
 
 			// Any problems?
 			if ( alGetError() != AL_NO_ERROR )
-				Ogre::LogManager::getSingleton().logError("OgreOggStreamSound::_dequeue() - Unable to unqueue buffers");
+				OGRE_LOG_ERROR("OgreOggStreamSound::_dequeue() - Unable to unqueue buffers");
 		}
 	}		 
 	/*/////////////////////////////////////////////////////////////////*/
@@ -545,7 +545,7 @@ namespace OgreOggSound
 		alSourcePlay(mSource);
 		if ( alGetError() )
 		{
-			Ogre::LogManager::getSingleton().logError("OgreOggStreamSound::_playImpl() - Unable to play sound");
+			OGRE_LOG_ERROR("OgreOggStreamSound::_playImpl() - Unable to play sound");
 			return;
 		}
 		// Set play flag

--- a/oggsound/src/OgreOggStreamWavSound.cpp
+++ b/oggsound/src/OgreOggStreamWavSound.cpp
@@ -40,12 +40,12 @@ namespace OgreOggSound
 	OgreOggStreamWavSound::OgreOggStreamWavSound(
 		const Ogre::String& name
 		#if OGRE_VERSION_MAJOR == 2
-		, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
+		, Ogre::SceneManager* scnMgr, Ogre::IdType id, Ogre::ObjectMemoryManager *objMemMgr, Ogre::uint8 renderQueueId
 		#endif
 	) : OgreOggISound(
 		name
 		#if OGRE_VERSION_MAJOR == 2
-		, id, objMemMgr, renderQueueId
+		, scnMgr, id, objMemMgr, renderQueueId
 		#endif
 	)
 	, mLoopOffsetBytes(0)
@@ -218,7 +218,7 @@ namespace OgreOggSound
 			}
 			else			
 			{
-				Ogre::LogManager::getSingleton().logError("OgreOggStreamWavSound::_openImpl() - Loop time invalid!");
+				OGRE_LOG_ERROR("OgreOggStreamWavSound::_openImpl() - Loop time invalid!");
 				mLoopOffset=0.f;
 			}
 		}
@@ -504,7 +504,7 @@ namespace OgreOggSound
 			// Check valid loop point
 			if ( mLoopOffset>=mPlayTime ) 
 			{
-				Ogre::LogManager::getSingleton().logError("OgreOggStreamWavSound::setLoopOffset() - Loop time invalid!");
+				OGRE_LOG_ERROR("OgreOggStreamWavSound::setLoopOffset() - Loop time invalid!");
 				return;
 			}
 
@@ -645,7 +645,7 @@ namespace OgreOggSound
 			// Any problems?
 			if ( alGetError() ) 
 			{
-				Ogre::LogManager::getSingleton().logError("OgreOggStreamWavSound::_dequeue() - Unable to unqueue buffers");
+				OGRE_LOG_ERROR("OgreOggStreamWavSound::_dequeue() - Unable to unqueue buffers");
 			}
 		}
 	}
@@ -679,7 +679,7 @@ namespace OgreOggSound
 		alSourcePlay(mSource);
 		if ( alGetError() )
 		{
-			Ogre::LogManager::getSingleton().logError("OgreOggStreamWavSound::_playImpl() - Unable to play sound");
+			OGRE_LOG_ERROR("OgreOggStreamWavSound::_playImpl() - Unable to play sound");
 			return;
 		}
 

--- a/theoravideo/src/OgreVideoManager.cpp
+++ b/theoravideo/src/OgreVideoManager.cpp
@@ -208,9 +208,15 @@ namespace Ogre
 	void OgreVideoPlugin::install()
 	{
 		if (mVideoMgr) {
+			#if OGRE_VERSION_MAJOR == 2
+			Ogre::LogManager::getSingleton().logMessage(Ogre::LML_CRITICAL,
+				"OgreVideoPlugin was already been initialized ... ignoring next initialise of plugin"
+			);
+			#else
 			Ogre::LogManager::getSingleton().logWarning(
 				"OgreVideoPlugin was already been initialized ... ignoring next initialise of plugin"
 			);
+			#endif
 			return;
 		}
 		


### PR DESCRIPTION
* add FindOGRE to cmake build (Ogre2 don't install cmake config file)
* use macro OGRE_LOG_ERROR instead of direct use logError (no logError in Ogre2)
* re-add `Ogre::SceneManager*` to `OgreOggListener` (in Ogre2-only part) -  constructor of MovableObject in Ogre2 need SceneManager