### PR TITLE
Give OgreOggListener its own Movable Object Type name

### DIFF
--- a/oggsound/include/OgreOggISound.h
+++ b/oggsound/include/OgreOggISound.h
@@ -43,6 +43,8 @@
 
 namespace OgreOggSound
 {
+	extern const Ogre::String MOT_OGG_ISOUND;
+
 	//! Action to perform after a fade has completed.
 	/** 
 	@remarks

--- a/oggsound/include/OgreOggListener.h
+++ b/oggsound/include/OgreOggListener.h
@@ -37,6 +37,8 @@
 
 namespace OgreOggSound
 {
+	extern const Ogre::String MOT_OGG_LISTENER;
+
 	//! Listener object (Users ears)
 	/** Handles properties associated with the listener.
 	*/
@@ -91,8 +93,7 @@ namespace OgreOggSound
 		void update();
 		/** Gets the movable type string for this object.
 		@remarks
-			Overridden function from MovableObject, returns a 
-			Sound object string for identification.
+			Overridden function from MovableObject.
 		 */
 		const Ogre::String& getMovableType(void) const override;
 		/** Gets the bounding box of this object.

--- a/oggsound/include/OgreOggSoundFactory.h
+++ b/oggsound/include/OgreOggSoundFactory.h
@@ -51,8 +51,6 @@ namespace OgreOggSound
 		OgreOggSoundFactory() {}
 		~OgreOggSoundFactory() {}
 
-		static const Ogre::String FACTORY_TYPE_NAME;
-
 		const Ogre::String& getType(void) const;
 		
 		#if AV_OGRE_NEXT_VERSION >= 0x20000

--- a/oggsound/src/OgreOggISound.cpp
+++ b/oggsound/src/OgreOggISound.cpp
@@ -694,9 +694,11 @@ namespace OgreOggSound
 		_updateFade(fTime);
 	}
 	/*/////////////////////////////////////////////////////////////////*/
+	const Ogre::String MOT_OGG_ISOUND = "OgreOggISound";
+	/*/////////////////////////////////////////////////////////////////*/
 	const Ogre::String& OgreOggISound::getMovableType(void) const
 	{
-		return OgreOggSoundFactory::FACTORY_TYPE_NAME;
+		return MOT_OGG_ISOUND;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
 	const Ogre::AxisAlignedBox& OgreOggISound::getBoundingBox(void) const

--- a/oggsound/src/OgreOggListener.cpp
+++ b/oggsound/src/OgreOggListener.cpp
@@ -104,9 +104,11 @@ namespace OgreOggSound
 		return 0;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
+	const Ogre::String MOT_OGG_LISTENER = "OgreOggListener";
+	/*/////////////////////////////////////////////////////////////////*/
 	const Ogre::String& OgreOggListener::getMovableType(void) const
 	{
-		return OgreOggSoundFactory::FACTORY_TYPE_NAME;
+		return MOT_OGG_LISTENER;
 	}
 	/*/////////////////////////////////////////////////////////////////*/
 	void OgreOggListener::_notifyAttached(

--- a/oggsound/src/OgreOggSoundFactory.cpp
+++ b/oggsound/src/OgreOggSoundFactory.cpp
@@ -35,12 +35,10 @@
 
 namespace OgreOggSound
 {
-	const Ogre::String OgreOggSoundFactory::FACTORY_TYPE_NAME = "OgreOggISound";
-
 	//-----------------------------------------------------------------------
 	const Ogre::String& OgreOggSoundFactory::getType(void) const
 	{
-		return FACTORY_TYPE_NAME;
+		return MOT_OGG_ISOUND;
 	}
 	//-----------------------------------------------------------------------
 	#if AV_OGRE_NEXT_VERSION >= 0x20100

--- a/oggsound/src/OgreOggSoundManager.cpp
+++ b/oggsound/src/OgreOggSoundManager.cpp
@@ -215,7 +215,7 @@ namespace OgreOggSound
 		#endif
 		{
 			Ogre::SceneManager* s = mListener->getSceneManager();
-			s->destroyAllMovableObjectsByType(OgreOggSoundFactory::FACTORY_TYPE_NAME);
+			s->destroyAllMovableObjectsByType(MOT_OGG_ISOUND);
 		}
 		_destroyListener();
 	}
@@ -525,9 +525,9 @@ namespace OgreOggSound
 		{
 			sound = static_cast<OgreOggISound*>(
 			#if AV_OGRE_NEXT_VERSION >= 0x20000
-				scnMgr->createMovableObject( OgreOggSoundFactory::FACTORY_TYPE_NAME, &(scnMgr->_getEntityMemoryManager(Ogre::SCENE_DYNAMIC)), &params )
+				scnMgr->createMovableObject( MOT_OGG_ISOUND, &(scnMgr->_getEntityMemoryManager(Ogre::SCENE_DYNAMIC)), &params )
 			#else
-				scnMgr->createMovableObject( name, OgreOggSoundFactory::FACTORY_TYPE_NAME, &params )
+				scnMgr->createMovableObject( name, MOT_OGG_ISOUND, &params )
 			#endif
 			);
 		}


### PR DESCRIPTION
OgreOggListener's override of MovableObject::getMovableType() returns the same name as OgreOggISound. One of the main reasons for getting the type is to be able to cast the pointer to a pointer to a specific derived class, which this shared name prevents. A current workaround is to compare the pointer to the singleton's listener:

```
	for (Ogre::MovableObject * mo : sn->getAttachedObjects())
	{
		if ((mo->getMovableType() == OgreOggSound::OgreOggSoundFactory::FACTORY_TYPE_NAME) &&
			(mo != OgreOggSound::OgreOggSoundManager::getSingleton().getListener()))
		{
			OgreOggSound::OgreOggISound * sound = static_cast<OgreOggSound::OgreOggISound *>(mo);
		}
	}
```

This PR gives the Listener its own name. It also changes the constants' names to the new MOT_* style. It breaks existing code so I understand if you don't want to merge this one.